### PR TITLE
docs: refresh InnoDI and InnoNetwork blog posts for v3 surface

### DIFF
--- a/_posts/2026-02-23-innodi-swift-macro-di-en.md
+++ b/_posts/2026-02-23-innodi-swift-macro-di-en.md
@@ -12,143 +12,131 @@ comments: true
 
 ## Introduction
 
-Since Swift 5.9, the macro system has significantly reduced boilerplate code. A well-known example is `@Observable`, which helps keep declarations concise.
+When I first introduced `InnoDI`, the framing was mostly "a Swift Macro library that removes DI boilerplate." That description is still directionally true, but it no longer captures the real public surface of `3.0.1`.
 
-However, dependency injection (DI) is still often handled either manually or with runtime-based libraries. Manual wiring becomes verbose, and runtime wiring can hide configuration issues until execution time.
+Today, the core story is **static dependency graph and scope validation**.
 
-**InnoDI** is a Swift Macro-based DI library designed to improve this experience. It diagnoses major setup issues at compile time and generates repetitive initialization code automatically.
+In other words, `InnoDI` is not a runtime service locator. It is a framework for declaring DI wiring explicitly and rejecting invalid graphs as early as possible at compile time and build time.
 
-## What InnoDI Solves
+This post revisits `InnoDI` from that perspective.
 
-### Limits of common DI approaches
+## Why revisit it now
 
-| Approach | Pros | Cons |
-|------|------|------|
-| Manual DI | Type-safe, explicit | Too much boilerplate |
-| Runtime DI (e.g., Swinject) | Flexible | Setup issues may surface at runtime |
-| Property Wrapper (`@Dependency`) | Convenient | Implicit dependencies can increase test complexity |
+The `3.0.x` line is not mainly about new macro syntax. The bigger shift is that the framework makes its validation boundaries much more explicit:
 
-### InnoDI approach
+- strict name-based resolution
+- declaration-order enforcement
+- `concrete: true` opt-in
+- `asyncFactory` scope restrictions
+- custom `init` rejection for `@DIContainer` types
+- build-stage DAG validation and plugin-based enforcement
 
-```text
-Compile-time diagnostics + automatic code generation + protocol-first design
-```
+So if we describe `InnoDI` only as "a macro that generates init code," we miss the part that matters most in a larger codebase: **which wiring patterns are allowed, and which are rejected**.
 
-1. **Compile-time diagnostics**: catches critical issues such as circular references and missing dependencies during build.
-2. **Code generation**: macros generate init/factory wiring automatically.
-3. **Protocol-first design**: encourages DIP-oriented architecture and easier testing.
+## What InnoDI owns and what it does not
 
----
+The README describes `InnoDI` as a **static dependency graph and scope validation** framework.
 
-## Core Concepts
+What `InnoDI` owns:
 
-### 1. `@DIContainer`
+- dependency wiring declared with `@DIContainer` and `@Provide`
+- lifecycle modeling through `DIScope`
+- compile-time and build-time validation
+- DAG rendering and validation artifacts
 
-Macro for declaring a struct as a DI container.
+What `InnoDI` does not own:
+
+- runtime state transitions
+- navigation policy
+- network session or transport lifecycle
+- container resolution as a runtime state machine
+
+Within the InnoSquad stack, state transitions belong in `InnoFlow`, navigation belongs in `InnoRouter`, and transport/session lifecycle belongs in `InnoNetwork`. `InnoDI` stays focused on **static wiring** across those layers.
+
+## Core API
+
+## Install
+
+For `InnoDI 3.0.1`, the package setup starts here.
 
 ```swift
-@DIContainer
-struct AppContainer {
-    // dependency declarations
-}
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.1")
+]
 ```
 
-#### Options
+Then add the product to your target.
 
-| Parameter | Default | Description |
-|----------|--------|------|
-| `validate` | `true` | Enables compile-time validation |
-| `root` | `false` | Marks root container in CLI graph output |
-| `validateDAG` | `true` | Participates in DAG cycle validation |
-| `mainActor` | `false` | Applies `@MainActor` isolation |
+```swift
+.target(
+    name: "YourApp",
+    dependencies: ["InnoDI"]
+)
+```
 
-### 2. `@Provide`
+### `@DIContainer`
 
-Macro used to register dependencies.
+Declare a struct as a DI container.
+
+```swift
+@DIContainer(validate: true, root: false, validateDAG: true, mainActor: false)
+struct AppContainer {}
+```
+
+Two things matter here:
+
+- the macro generates container initializers and accessors
+- the same declaration is also validation input
+
+There is an important constraint as well: a type annotated with `@DIContainer` cannot define its own custom `init`. That rule is enforced in the type body, same-file extensions, and cross-file extensions during build validation.
+
+### `@Provide`
+
+Declare a dependency.
 
 ```swift
 @Provide(
     _ scope: DIScope = .shared,
-    _ type: Any.Type? = nil,
-    with dependencies: [AnyKeyPath] = [],
+    _ type: Type.self? = nil,
+    with: [KeyPath] = [],
     factory: Any? = nil,
     asyncFactory: Any? = nil,
     concrete: Bool = false
 )
 ```
 
-### 3. `DIScope` - lifecycle of dependencies
+There are three main styles:
+
+- receive external values with `.input`
+- describe construction with `factory` or `asyncFactory`
+- use `Type.self` + `with:` for AutoWiring
+
+### `DIScope`
+
+In `InnoDI`, scope is not just a convenience feature. It is directly tied to validation rules.
+
+| Scope | Meaning | Notes |
+|------|------|------|
+| `.input` | must be injected when the container is created | no factory allowed |
+| `.shared` | created once and cached for the container lifetime | order rules apply |
+| `.transient` | creates a fresh instance on each access | not cached |
+
+## A minimal example
+
+This is the shape most users start with.
 
 ```swift
-public enum DIScope {
-    case shared     // created once per container and reused
-    case input      // must be injected from outside when container is created
-    case transient  // new instance every access
-}
-```
+import InnoDI
 
----
-
-## Usage
-
-### Basic setup
-
-#### 1. Add package in `Package.swift`
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.0.0")
-]
-```
-
-#### 2. Add product dependency to target
-
-```swift
-.target(
-    name: "YourApp",
-    dependencies: [
-        .product(name: "InnoDI", package: "InnoDI")
-    ]
-)
-```
-
-### Register dependencies
-
-#### `.input` - external dependencies
-
-Values that must be decided at app startup.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var baseURL: String
-
-    @Provide(.input)
-    var apiKey: String
+protocol APIClientProtocol {
+    func fetch() async throws -> Data
 }
 
-let container = AppContainer(
-    baseURL: "https://api.example.com",
-    apiKey: "your-api-key"
-)
-```
-
-#### `.shared` - shared per container
-
-Created once per container lifecycle.
-
-```swift
-protocol NetworkServiceProtocol {
-    func request(_ endpoint: String) async throws -> Data
-}
-
-struct NetworkService: NetworkServiceProtocol {
+struct APIClient: APIClientProtocol {
     let baseURL: String
-    let session: URLSession
 
-    func request(_ endpoint: String) async throws -> Data {
-        // implementation
+    func fetch() async throws -> Data {
+        Data()
     }
 }
 
@@ -157,36 +145,19 @@ struct AppContainer {
     @Provide(.input)
     var baseURL: String
 
-    @Provide(.shared, factory: { (baseURL: String) in
-        NetworkService(baseURL: baseURL, session: .shared)
-    })
-    var networkService: any NetworkServiceProtocol
-}
-```
-
-#### `.transient` - always a new instance
-
-Best for objects like ViewModels that should hold fresh state.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var networkService: any NetworkServiceProtocol
-
-    @Provide(.transient, factory: { (network: any NetworkServiceProtocol) in
-        HomeViewModel(networkService: network)
-    }, concrete: true)
-    var homeViewModel: HomeViewModel
+    @Provide(.shared, APIClient.self, with: [\.baseURL])
+    var apiClient: any APIClientProtocol
 }
 
-let vm1 = container.homeViewModel
-let vm2 = container.homeViewModel
+let container = AppContainer(baseURL: "https://api.example.com")
+let client = container.apiClient
 ```
 
-### AutoWiring
+The most important part is not the generated code. It is the **strict matching rule**: the key paths listed in `with:` must match the initializer parameter names of the concrete type exactly.
 
-Wire dependencies of dependencies automatically.
+## AutoWiring and strict matching
+
+One of the defining characteristics of `InnoDI 3.x` is that **name-based resolution is intentionally strict**.
 
 ```swift
 @DIContainer
@@ -202,239 +173,183 @@ struct AppContainer {
 }
 ```
 
-Conceptually, macro-generated code looks like this:
+Conceptually, this expects something like `APIClient(config:logger:)`. If the names do not match, the macro does not try to guess.
+
+That can feel rigid, but it also means the declaration and the generated wiring follow the exact same rule. Humans and tools read the graph the same way.
+
+When names do not line up, a factory closure is the better choice.
 
 ```swift
-init(config: AppConfig, logger: Logger) {
-    self.config = config
-    self.logger = logger
-    self._apiClient = APIClient(config: config, logger: logger)
-}
-```
-
-### Async factory
-
-If async initialization is required, use `asyncFactory`.
-
-```swift
-@Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
-    try await DatabaseService.connect(config: config)
+@Provide(.shared, factory: { (config: AppConfig) in
+    APIClient(configuration: config, timeout: 30)
 })
-var database: any DatabaseServiceProtocol
+var apiClient: any APIClientProtocol
 ```
 
----
+## Declaration order and scope rules
 
-## Testing
+According to `PolicyBoundaries.md`, declaration order is part of the validation contract.
 
-### Inject mocks with init override
+- `.input` members are always available
+- sync `.shared` members can reference inputs and **earlier** sync shared members
+- async `.shared` members can reference inputs, all sync shared members, and **earlier** async shared members
+- `.transient` members may reference any container member, but matching is still strict
 
-One of InnoDI's key strengths is **constructor override**.
+That means member order is not just style. It defines **dependency availability**.
+
+## `concrete: true` and protocol-first design
+
+`InnoDI` is protocol-first by default. Exposing a concrete shared or transient dependency requires explicit opt-in.
 
 ```swift
 @DIContainer
 struct AppContainer {
     @Provide(.input)
-    var baseURL: String
-
-    @Provide(.shared, factory: { (url: String) in
-        APIClient(baseURL: url)
-    })
     var apiClient: any APIClientProtocol
+
+    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
+        HomeViewModel(apiClient: apiClient)
+    }, concrete: true)
+    var homeViewModel: HomeViewModel
 }
+```
 
-let container = AppContainer(baseURL: "https://api.example.com")
+This is a small but useful rule. It makes concrete exposure deliberate instead of accidental and nudges the codebase toward dependency inversion.
 
-let testContainer = AppContainer(
+## Async factories and their limits
+
+Use `asyncFactory` when construction is asynchronous.
+
+```swift
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var config: AppConfig
+
+    @Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
+        try await DatabaseClient.connect(config: config)
+    })
+    var databaseClient: any DatabaseClientProtocol
+}
+```
+
+Again, the framework is explicit about what it allows:
+
+- `factory` and `asyncFactory` cannot be used together
+- `.input` cannot use `asyncFactory`
+- `asyncFactory` must actually be an `async` closure
+
+This is a good example of the broader `3.x` direction: not just "we support it," but "we define the boundary precisely."
+
+## Validation layers
+
+This is where `InnoDI` becomes much more than a macro convenience layer.
+
+### 1. Local container validation
+
+At macro expansion time, `InnoDI` validates:
+
+- unknown scopes
+- missing factories
+- invalid `.input` factory configuration
+- strict name-based resolution
+- declaration-order violations
+- missing `concrete: true`
+- local cycles and unknown dependencies
+- async factory validity
+- same-file `init` conflicts
+
+### 2. Build-stage validation
+
+Build validation scans package sources more broadly and extends the rule set to **cross-file extension `init` conflicts**.
+
+So macro success is not the whole story. The build phase tightens the contract further.
+
+### 3. Global DAG validation
+
+Graph-wide cycles and ambiguity are validated through the CLI or the build plugin.
+
+```bash
+swift run InnoDI-DependencyGraph --root . --validate-dag
+```
+
+You can also opt a container out of DAG validation:
+
+```swift
+@DIContainer(validateDAG: false)
+struct PreviewContainer {
+    @Provide(.input)
+    var mockAPIClient: any APIClientProtocol
+}
+```
+
+That is best used for preview or test containers that you do not want included in the global graph contract.
+
+## `PolicyBoundaries` and custom `init` restrictions
+
+To understand `3.0.x`, the README is not enough. `PolicyBoundaries.md` matters because it explains the framework's determinism choices.
+
+Key points:
+
+- cross-file extension targets try semantic resolution first
+- ambiguous or unsupported cases are not guessed
+- generic argument extensions and constrained `where` extensions are excluded from the build-stage custom `init` rule
+- nested paths such as `Outer.Container` are supported
+
+This is a deliberate tradeoff. `InnoDI` prefers **deterministic validation** over speculative matching.
+
+## Testing and override strategy
+
+The main testing story is not a separate runtime override registry. It is the generated initializer with override parameters.
+
+```swift
+let container = AppContainer(
     baseURL: "https://test.example.com",
     apiClient: MockAPIClient()
 )
 ```
 
-You can pass test doubles directly without maintaining a separate `Overrides` struct.
+That has two practical benefits:
 
----
+- the difference between production and test wiring is visible directly in the initializer
+- mock replacement works without a runtime registry or container mutation step
 
-## Compile-Time Validation
+## CLI, plugin, and artifacts
 
-### Detect circular dependencies
+In a team setting, the most important part is often not the macro diagnostic itself but the **plugin and artifacts**.
 
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.shared, factory: ServiceA(serviceB: serviceB), concrete: true)
-    var serviceA: ServiceA
+Attach `InnoDIDAGValidationPlugin` to a target if you want DAG problems to fail the build. During validation, the framework produces artifacts such as:
 
-    @Provide(.shared, factory: ServiceB(serviceA: serviceA), concrete: true)
-    var serviceB: ServiceB  // ❌ compile error
-}
-// Error: "Dependency cycle detected: serviceA -> serviceB -> serviceA"
-```
+- `result.json`
+- `validation-metrics.json`
+- `validation-summary.md`
+- `dag-validation-stamp.txt`
+- `dag-validation-metrics.json`
+- `dag-validation-summary.md`
 
-### Protocol-first guidance (DIP-oriented)
+In CI, those summaries and metrics are usually more useful than raw stderr alone.
 
-```swift
-// ❌ explicit opt-in required for concrete type
-@Provide(.shared, factory: APIClient())
-var apiClient: APIClient
+## When to use which option
 
-// ✅ use protocol type
-@Provide(.shared, factory: APIClient())
-var apiClient: any APIClientProtocol
+| Situation | Recommended choice |
+|------|------|
+| external values at app startup | `.input` |
+| services reused for one container lifetime | `.shared` |
+| ViewModels or adapters that need fresh instances | `.transient` with `concrete: true` when needed |
+| initializer parameter names match member names | `Type.self` + `with:` |
+| names differ or custom mapping is needed | `factory` |
+| async construction is required | `asyncFactory` |
+| preview or test-only containers should stay out of global DAG checks | `validateDAG: false` |
 
-// ✅ use concrete when needed
-@Provide(.shared, concrete: true, factory: APIClient())
-var apiClient: APIClient
-```
+## Closing thoughts
 
-### Validation scope
+If I had to summarize `InnoDI 3.0.1` in one sentence, I would no longer call it just "macro-based DI." A better description is **a DI wiring framework with explicit static graph rules**.
 
-With default settings (`validate: true`), major configuration issues are diagnosed at compile time. If you relax this with `validate: false`, some missing-wiring cases may fall back to runtime `fatalError`.
+Reducing boilerplate is still useful. But in a larger codebase, the real value is that wiring failures show up during the build instead of surfacing later as runtime surprises.
 
----
+If you want to go deeper, this reading order works best:
 
-## Visualize Dependency Graphs
-
-InnoDI provides a CLI tool to visualize dependency graphs.
-
-### Mermaid output
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project
-```
-
-```mermaid
-graph TD
-    A[AppContainer] --> B[apiClient]
-    A --> C[networkService]
-    B --> D[config]
-    C --> D
-```
-
-### Graphviz DOT output
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project --format dot --output graph.dot
-```
-
-### DAG validation
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project --validate-dag
-```
-
-### Build tool plugin
-
-You can validate automatically during builds by adding a plugin in `Package.swift`.
-
-```swift
-.target(
-    name: "YourApp",
-    dependencies: ["InnoDI"],
-    plugins: [
-        .plugin(name: "InnoDIDAGValidationPlugin", package: "InnoDI")
-    ]
-)
-```
-
----
-
-## Real Architecture Example
-
-### Using with clean architecture
-
-```swift
-protocol WeatherRepository {
-    func fetchWeather(city: String) async throws -> Weather
-}
-
-struct WeatherRepositoryImpl: WeatherRepository {
-    let apiClient: any APIClientProtocol
-    let cache: any CacheProtocol
-
-    func fetchWeather(city: String) async throws -> Weather {
-        // implementation
-    }
-}
-
-@MainActor
-@Observable
-class WeatherViewModel {
-    let repository: any WeatherRepository
-
-    init(repository: any WeatherRepository) {
-        self.repository = repository
-    }
-}
-
-@DIContainer(mainActor: true)
-struct AppContainer {
-    @Provide(.input)
-    var baseURL: String
-
-    @Provide(.shared, APIClient.self, with: [\.baseURL])
-    var apiClient: any APIClientProtocol
-
-    @Provide(.shared, factory: { MemoryCache() })
-    var cache: any CacheProtocol
-
-    @Provide(.shared, WeatherRepositoryImpl.self, with: [\.apiClient, \.cache])
-    var weatherRepository: any WeatherRepository
-
-    @Provide(.transient, WeatherViewModel.self, with: [\.weatherRepository], concrete: true)
-    var weatherViewModel: WeatherViewModel
-}
-
-@main
-struct WeatherApp: App {
-    let container = AppContainer(baseURL: "https://api.weather.com")
-
-    var body: some Scene {
-        WindowGroup {
-            WeatherView(viewModel: container.weatherViewModel)
-        }
-    }
-}
-```
-
----
-
-## Comparison with alternatives
-
-| Feature | InnoDI | Swinject | Factory | Manual |
-|------|--------|----------|---------|------|
-| Compile-time validation | Strong | Weak | Partial | Strong (if done carefully) |
-| Cycle detection | Supported | Limited | Limited | Manual checks required |
-| Boilerplate | Low | Medium | Low | High |
-| Runtime misconfiguration risk | Low (with defaults) | Present | Low | Low |
-| Learning curve | Low to medium | Medium | Low | None |
-| SwiftUI integration | Easy | Easy | Easy | Easy |
-
----
-
-## Conclusion
-
-InnoDI is a library that improves both DI quality and developer experience by leveraging Swift macros.
-
-### Recommended for
-
-- Projects adopting **clean architecture**
-- Teams that care about **testability**
-- Teams that want to reduce **runtime wiring errors**
-- Developers who want to remove repetitive **boilerplate**
-
-### Key benefits
-
-1. **Compile-time diagnostics** for major setup issues.
-2. **Automatic code generation** for repetitive initialization.
-3. **Protocol-first design** aligned with testable architecture.
-4. **Simple mock injection** via init override.
-5. **Dependency graph visualization** for faster architecture understanding.
-
----
-
-## References
-
-- [InnoDI GitHub Repository](https://github.com/InnoSquadCorp/InnoDI)
-- [Swift Macro Documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/)
-- [Dependency Inversion Principle (DIP)](https://en.wikipedia.org/wiki/Dependency_inversion_principle)
+1. [README](https://github.com/InnoSquadCorp/InnoDI)
+2. [`Validation.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/Validation.md)
+3. [`PolicyBoundaries.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md)
+4. [`ModuleWideInitDetection.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md)

--- a/_posts/2026-02-23-innodi-swift-macro-di.md
+++ b/_posts/2026-02-23-innodi-swift-macro-di.md
@@ -12,144 +12,129 @@ comments: true
 
 ## 들어가며
 
-Swift 5.9부터 도입된 Macro 시스템은 Swift 코드의 보일러플레이트를 줄이는 데 큰 역할을 하고 있습니다. `@Observable`처럼 선언을 간결하게 만들어 주는 기능이 대표적입니다.
+`InnoDI`를 처음 소개했을 때는 "Swift Macro로 DI 보일러플레이트를 줄여주는 라이브러리"라는 설명이 중심이었습니다. 그 설명도 여전히 틀리지는 않지만, `3.0.1` 기준의 실제 공개 surface를 보면 지금의 핵심은 **정적 dependency graph와 scope validation**입니다.
 
-하지만 **의존성 주입(Dependency Injection)** 영역에서는 여전히 수동으로 코드를 작성하거나, 런타임 기반 라이브러리에 의존하는 경우가 많습니다. 수동 구성은 장황해지기 쉽고, 런타임 기반 방식은 설정 실수가 실행 중 문제로 드러날 수 있습니다.
+즉, `InnoDI`는 런타임 service locator가 아니라 **DI wiring을 명시적으로 선언하고, 잘못된 그래프를 컴파일/빌드 단계에서 최대한 빨리 막는 프레임워크**에 가깝습니다.
 
-**InnoDI**는 이 지점을 개선하기 위해 만들어진 Swift Macro 기반 DI 라이브러리입니다. 주요 설정 오류를 컴파일 타임에 진단하고, 반복적인 초기화 코드를 자동 생성해 개발 경험을 개선합니다.
+이 글은 그 기준으로 `InnoDI`를 다시 정리합니다.
 
-## InnoDI가 해결하는 문제
+## 왜 다시 봐야 하나
 
-### 기존 DI 방식의 한계
+`3.0.x`에서 `InnoDI`의 중심은 새 매크로 문법이 아닙니다. 오히려 아래 같은 검증 경계가 더 또렷해졌습니다.
 
-| 방식 | 장점 | 단점 |
-|------|------|------|
-| 수동 의존성 주입 | 타입 안전, 명시적 | 보일러플레이트 과다 |
-| 런타임 DI (Swinject 등) | 유연함 | 설정 오류가 런타임에 드러날 수 있음 |
-| Property Wrapper (@Dependency) | 간편함 | 암시적 의존성, 테스트 복잡도 증가 가능 |
+- strict name-based resolution
+- declaration-order enforcement
+- `concrete: true` opt-in
+- `asyncFactory`의 scope 제약
+- `@DIContainer`가 선언된 타입의 custom `init` 금지
+- build-stage DAG validation과 plugin 기반 검증
 
-### InnoDI의 접근법
+그래서 지금 `InnoDI`를 설명할 때는 "매크로가 init을 생성해 준다"에서 멈추면 부족합니다. **어떤 wiring이 허용되고, 어떤 wiring이 거부되는지**까지 함께 설명해야 실제 코드베이스와 맞습니다.
 
-```
-컴파일 타임 진단 + 자동 코드 생성 + 프로토콜 우선 설계
-```
+## InnoDI가 소유하는 것과 소유하지 않는 것
 
-1. **컴파일 타임 진단**: 순환 참조, 누락된 의존성 같은 주요 설정 오류를 빌드 시점에 확인합니다.
-2. **자동 코드 생성**: init 및 팩토리 연결 코드를 매크로가 자동으로 생성합니다.
-3. **프로토콜 우선**: DIP(의존성 역전 원칙) 지향 설계를 통해 테스트 용이성을 높입니다.
+README의 표현을 그대로 빌리면, `InnoDI`는 **static dependency graph and scope validation** 프레임워크입니다.
 
----
+`InnoDI`가 소유하는 것:
 
-## 핵심 개념
+- `@DIContainer`와 `@Provide`로 선언한 의존성 wiring
+- `DIScope` 기반 수명주기 표현
+- compile-time / build-time validation
+- DAG 시각화와 validation artifact
 
-### 1. `@DIContainer`
+`InnoDI`가 소유하지 않는 것:
 
-DI 컨테이너로 사용할 struct를 선언하는 매크로입니다.
+- 런타임 상태 전이
+- 화면 이동이나 navigation policy
+- 네트워크 세션/transport lifecycle
+- 컨테이너 해석을 이용한 runtime state machine
+
+InnoSquad 스택 기준으로 보면 상태 전이는 `InnoFlow`, navigation은 `InnoRouter`, transport/session lifecycle은 `InnoNetwork` 쪽 책임입니다. `InnoDI`는 이 레이어들을 연결하는 **정적 wiring**에 집중합니다.
+
+## 핵심 API
+
+## 설치
+
+`InnoDI 3.0.1` 기준 설치는 아래처럼 시작하면 됩니다.
 
 ```swift
-@DIContainer
-struct AppContainer {
-    // 의존성 선언
-}
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.1")
+]
 ```
 
-#### 옵션
+타겟에는 보통 이렇게 연결합니다.
 
-| 파라미터 | 기본값 | 설명 |
-|----------|--------|------|
-| `validate` | `true` | 컴파일 타임 검증 활성화 |
-| `root` | `false` | CLI 그래프에서 루트 컨테이너 표시 |
-| `validateDAG` | `true` | DAG 순환 참조 검증 참여 여부 |
-| `mainActor` | `false` | `@MainActor` 격리 적용 |
+```swift
+.target(
+    name: "YourApp",
+    dependencies: ["InnoDI"]
+)
+```
 
-### 2. `@Provide`
+### `@DIContainer`
 
-의존성을 선언하는 매크로입니다.
+컨테이너 struct를 선언합니다.
+
+```swift
+@DIContainer(validate: true, root: false, validateDAG: true, mainActor: false)
+struct AppContainer {}
+```
+
+핵심 포인트는 두 가지입니다.
+
+- 매크로가 컨테이너 initializer와 accessor를 생성합니다.
+- 동시에 잘못된 wiring을 컴파일 단계에서 거부합니다.
+
+또 하나 중요한 제약이 있습니다. `@DIContainer`가 붙은 타입에는 user-defined `init`을 둘 수 없습니다. 타입 본문은 물론, same-file extension과 cross-file extension까지 build validation이 확인합니다.
+
+### `@Provide`
+
+의존성을 선언합니다.
 
 ```swift
 @Provide(
     _ scope: DIScope = .shared,
-    _ type: Any.Type? = nil,
-    with dependencies: [AnyKeyPath] = [],
+    _ type: Type.self? = nil,
+    with: [KeyPath] = [],
     factory: Any? = nil,
     asyncFactory: Any? = nil,
     concrete: Bool = false
 )
 ```
 
-### 3. `DIScope` - 의존성 생명주기
+선언 방식은 크게 세 가지입니다.
+
+- `.input`으로 외부 입력을 받기
+- `factory` / `asyncFactory`로 생성 규칙을 명시하기
+- `Type.self` + `with:` 조합으로 AutoWiring 쓰기
+
+### `DIScope`
+
+`InnoDI`의 scope는 단순한 convenience가 아니라, validation 규칙과 직접 연결됩니다.
+
+| Scope | 의미 | 비고 |
+|------|------|------|
+| `.input` | 컨테이너 생성 시 외부에서 반드시 주입 | factory 불가 |
+| `.shared` | 컨테이너 수명 동안 1회 생성 후 재사용 | sync/async declaration order 규칙 적용 |
+| `.transient` | 접근할 때마다 새 인스턴스 생성 | 캐시되지 않음 |
+
+## 시작 예제
+
+가장 기본적인 모습은 아래와 같습니다.
 
 ```swift
-public enum DIScope {
-    case shared     // 컨테이너당 1회 생성 후 재사용
-    case input      // 컨테이너 생성 시 외부에서 주입 필수
-    case transient  // 접근할 때마다 새 인스턴스 생성
-}
-```
+import InnoDI
 
----
-
-## 사용법
-
-### 기본 설정
-
-#### 1. Package.swift 추가
-
-```swift
-dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "2.0.0")
-]
-```
-
-#### 2. 타겟에 의존성 추가
-
-```swift
-.target(
-    name: "YourApp",
-    dependencies: [
-        .product(name: "InnoDI", package: "InnoDI")
-    ]
-)
-```
-
-### 의존성 등록하기
-
-#### `.input` - 외부 의존성
-
-앱 실행 시점에 결정되어야 하는 값들입니다.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var baseURL: String
-
-    @Provide(.input)
-    var apiKey: String
+protocol APIClientProtocol {
+    func fetch() async throws -> Data
 }
 
-// 사용
-let container = AppContainer(
-    baseURL: "https://api.example.com",
-    apiKey: "your-api-key"
-)
-```
-
-#### `.shared` - 컨테이너 단위 공유 인스턴스
-
-컨테이너 수명 동안 한 번만 생성됩니다.
-
-```swift
-protocol NetworkServiceProtocol {
-    func request(_ endpoint: String) async throws -> Data
-}
-
-struct NetworkService: NetworkServiceProtocol {
+struct APIClient: APIClientProtocol {
     let baseURL: String
-    let session: URLSession
 
-    func request(_ endpoint: String) async throws -> Data {
-        // 구현
+    func fetch() async throws -> Data {
+        Data()
     }
 }
 
@@ -158,37 +143,19 @@ struct AppContainer {
     @Provide(.input)
     var baseURL: String
 
-    @Provide(.shared, factory: { (baseURL: String) in
-        NetworkService(baseURL: baseURL, session: .shared)
-    })
-    var networkService: any NetworkServiceProtocol
-}
-```
-
-#### `.transient` - 매번 새 인스턴스
-
-주로 ViewModel처럼 매번 새로운 상태가 필요한 객체에 사용합니다.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var networkService: any NetworkServiceProtocol
-
-    @Provide(.transient, factory: { (network: any NetworkServiceProtocol) in
-        HomeViewModel(networkService: network)
-    }, concrete: true)
-    var homeViewModel: HomeViewModel
+    @Provide(.shared, APIClient.self, with: [\.baseURL])
+    var apiClient: any APIClientProtocol
 }
 
-// 각 접근이 새 인스턴스 생성
-let vm1 = container.homeViewModel  // 새 인스턴스
-let vm2 = container.homeViewModel  // 또 다른 새 인스턴스
+let container = AppContainer(baseURL: "https://api.example.com")
+let client = container.apiClient
 ```
 
-### AutoWiring
+여기서 중요한 건 "자동 생성"보다 **엄격한 matching rule**입니다. `with:`에 넘긴 key path 이름은 concrete type의 init parameter 이름과 정확히 맞아야 합니다.
 
-의존성의 의존성을 자동으로 연결합니다.
+## AutoWiring과 strict matching
+
+`InnoDI 3.x`의 핵심 변화 중 하나는 **name-based resolution을 더 엄격하게 다루는 것**입니다.
 
 ```swift
 @DIContainer
@@ -199,264 +166,184 @@ struct AppContainer {
     @Provide(.input)
     var logger: Logger
 
-    // APIClient는 config와 logger가 필요
-    // AutoWiring이 자동으로 주입
     @Provide(.shared, APIClient.self, with: [\.config, \.logger])
     var apiClient: any APIClientProtocol
 }
 ```
 
-매크로는 개념적으로 아래와 같은 초기화를 생성합니다.
+위 선언은 개념적으로 `APIClient(config:logger:)` 같은 init을 기대합니다. 이름이 다르면 자동으로 맞춰주지 않습니다. 이 제약은 번거롭지만, 선언을 읽는 사람과 매크로가 **같은 wiring 규칙**을 보게 만든다는 장점이 있습니다.
+
+AutoWiring이 맞지 않는 경우는 factory closure를 쓰는 편이 낫습니다.
 
 ```swift
-// 자동 생성된 코드 (개념적 예시)
-init(config: AppConfig, logger: Logger) {
-    self.config = config
-    self.logger = logger
-    self._apiClient = APIClient(config: config, logger: logger)
-}
-```
-
-### 비동기 팩토리
-
-비동기 초기화가 필요한 경우에는 `asyncFactory`를 사용합니다.
-
-```swift
-@Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
-    try await DatabaseService.connect(config: config)
+@Provide(.shared, factory: { (config: AppConfig) in
+    APIClient(configuration: config, timeout: 30)
 })
-var database: any DatabaseServiceProtocol
+var apiClient: any APIClientProtocol
 ```
 
----
+## Declaration Order와 scope 규칙
 
-## 테스트하기
+`PolicyBoundaries.md` 기준으로 `InnoDI`는 선언 순서를 validation contract에 포함합니다.
 
-### Init Override로 Mock 주입
+- `.input`은 항상 참조 가능합니다.
+- sync `.shared`는 input과 **앞서 선언된** sync shared만 참조할 수 있습니다.
+- async `.shared`는 input, 모든 sync shared, 그리고 **앞서 선언된** async shared를 참조할 수 있습니다.
+- `.transient`는 어떤 멤버든 참조할 수 있지만 이름 matching은 여전히 엄격합니다.
 
-InnoDI의 핵심 장점 중 하나는 **생성자 오버라이드**입니다.
+즉, 컨테이너 멤버 순서가 단순 스타일이 아니라 **의존성 가용성 규칙**이 됩니다.
+
+## `concrete: true`와 protocol-first 설계
+
+`InnoDI`는 protocol-first 설계를 기본값으로 둡니다. 그래서 concrete shared/transient dependency를 직접 노출할 때는 opt-in이 필요합니다.
 
 ```swift
-// 프로덕션 코드
 @DIContainer
 struct AppContainer {
     @Provide(.input)
-    var baseURL: String
-
-    @Provide(.shared, factory: { (url: String) in
-        APIClient(baseURL: url)
-    })
     var apiClient: any APIClientProtocol
+
+    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
+        HomeViewModel(apiClient: apiClient)
+    }, concrete: true)
+    var homeViewModel: HomeViewModel
 }
+```
 
-// 프로덕션 사용
-let container = AppContainer(baseURL: "https://api.example.com")
-// container.apiClient -> 실제 APIClient 인스턴스
+이 규칙 덕분에 concrete 타입 노출이 "실수로" 늘어나는 것을 막고, 의존성 역전 원칙을 의식적으로 지키게 됩니다.
 
-// 테스트 사용 - Mock으로 오버라이드
-let testContainer = AppContainer(
+## 비동기 팩토리와 제약
+
+비동기 초기화가 필요하면 `asyncFactory`를 사용할 수 있습니다.
+
+```swift
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var config: AppConfig
+
+    @Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
+        try await DatabaseClient.connect(config: config)
+    })
+    var databaseClient: any DatabaseClientProtocol
+}
+```
+
+여기에도 명확한 제약이 있습니다.
+
+- `factory`와 `asyncFactory`는 동시에 사용할 수 없습니다.
+- `.input`에는 `asyncFactory`를 둘 수 없습니다.
+- `asyncFactory`는 실제 `async` closure여야 합니다.
+
+결국 `InnoDI`는 "지원한다"보다 "어디까지 허용한다"를 명확히 문서화한 프레임워크에 가깝습니다.
+
+## Validation Layers
+
+`InnoDI`의 진짜 가치가 드러나는 부분은 validation입니다.
+
+### 1. Local Container Validation
+
+매크로 단계에서 아래를 검사합니다.
+
+- unknown scope
+- missing factory
+- `.input`의 잘못된 factory 구성
+- strict name-based resolution
+- declaration-order 위반
+- `concrete: true` 누락
+- local cycle / unknown dependency
+- async factory validity
+- same-file `init` 충돌
+
+### 2. Build-Stage Validation
+
+빌드 단계에서는 same-package 소스를 더 넓게 스캔해서 **cross-file extension `init` 충돌**까지 확인합니다.
+
+즉, 매크로만 통과했다고 끝이 아니라 빌드 레벨에서 한 번 더 보강합니다.
+
+### 3. Global DAG Validation
+
+그래프 전체 차원의 순환과 ambiguity는 CLI나 build plugin으로 검증합니다.
+
+```bash
+swift run InnoDI-DependencyGraph --root . --validate-dag
+```
+
+필요하면 특정 컨테이너는 DAG 검증에서 제외할 수 있습니다.
+
+```swift
+@DIContainer(validateDAG: false)
+struct PreviewContainer {
+    @Provide(.input)
+    var mockAPIClient: any APIClientProtocol
+}
+```
+
+이 옵션은 "validation을 끄는 편의 기능"이라기보다, preview/test 전용 컨테이너처럼 **그래프 전역 검증에 참여시키고 싶지 않은 타입**을 분리하는 데 더 적합합니다.
+
+## `PolicyBoundaries`와 custom `init` restriction
+
+`3.0.x`를 이해하려면 README만으로는 부족하고, `PolicyBoundaries.md`를 같이 봐야 합니다. 핵심은 다음입니다.
+
+- cross-file extension target은 semantic resolution을 먼저 시도합니다.
+- ambiguous / unsupported case는 추측하지 않고 conservative fallback 또는 exclusion으로 처리합니다.
+- generic argument extension, constrained `where` extension은 build-stage custom `init` 규칙에서 제외됩니다.
+- nested path(`Outer.Container`) matching을 지원합니다.
+
+이 선택은 "최대한 많이 맞추겠다"보다 **deterministic validation**을 우선하는 방향입니다.
+
+## 테스트와 override 전략
+
+`InnoDI`의 테스트 경험은 별도 override container를 만드는 방식보다, **생성된 initializer override parameter**를 활용하는 쪽이 중심입니다.
+
+```swift
+let container = AppContainer(
     baseURL: "https://test.example.com",
     apiClient: MockAPIClient()
 )
-// testContainer.apiClient -> MockAPIClient 인스턴스
 ```
 
-별도의 `Overrides` 구조체 없이, 생성자에 Mock을 직접 전달하실 수 있습니다.
+이 방식의 장점은 두 가지입니다.
 
----
+- 프로덕션 wiring과 테스트 wiring의 차이가 init parameter에서 바로 드러납니다.
+- 별도의 runtime registry 없이 mock 교체가 가능합니다.
 
-## 컴파일 타임 검증
+## CLI, Plugin, Artifact
 
-### 순환 의존성 탐지
+실무에서 `InnoDI`를 팀 단위로 쓰게 되면 매크로 진단보다 **artifact와 plugin**이 중요해집니다.
 
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.shared, factory: ServiceA(serviceB: serviceB), concrete: true)
-    var serviceA: ServiceA
+`InnoDIDAGValidationPlugin`을 target에 붙이면 DAG 문제를 빌드 실패로 올릴 수 있습니다. 또한 validation 과정에서 아래 artifact가 생성됩니다.
 
-    @Provide(.shared, factory: ServiceB(serviceA: serviceA), concrete: true)
-    var serviceB: ServiceB  // ❌ 컴파일 에러
-}
-// Error: "Dependency cycle detected: serviceA -> serviceB -> serviceA"
-```
+- `result.json`
+- `validation-metrics.json`
+- `validation-summary.md`
+- `dag-validation-stamp.txt`
+- `dag-validation-metrics.json`
+- `dag-validation-summary.md`
 
-### 프로토콜 타입 우선 (DIP 지향)
+CI에서는 raw stderr만 보는 대신 Markdown summary와 metrics artifact를 우선 읽는 편이 훨씬 낫습니다.
 
-구체 타입 대신 프로토콜 사용을 기본으로 유도합니다.
+## 언제 어떤 옵션을 써야 하나
 
-```swift
-// ❌ 구체 타입은 명시적 opt-in 필요
-@Provide(.shared, factory: APIClient())
-var apiClient: APIClient  // Error
+| 상황 | 권장 선택 |
+|------|-----------|
+| 앱 시작 시 외부 값 주입 | `.input` |
+| 컨테이너 단위로 재사용할 서비스 | `.shared` |
+| 접근할 때마다 새 인스턴스가 필요한 ViewModel/Adapter | `.transient` + 필요 시 `concrete: true` |
+| init parameter 이름이 프로퍼티 이름과 정확히 맞음 | `Type.self` + `with:` |
+| 이름이 다르거나 변환 로직이 필요함 | `factory` |
+| 비동기 생성 필요 | `asyncFactory` |
+| preview/test 전용 컨테이너를 전역 DAG에서 분리 | `validateDAG: false` |
 
-// ✅ 프로토콜 타입 사용
-@Provide(.shared, factory: APIClient())
-var apiClient: any APIClientProtocol  // OK
+## 마무리
 
-// ✅ 구체 타입을 사용해야 한다면
-@Provide(.shared, concrete: true, factory: APIClient())
-var apiClient: APIClient  // OK
-```
+`InnoDI 3.0.1`을 한 문장으로 요약하면, "Swift Macro 기반 DI"보다 **정적 그래프 규칙이 명확한 DI wiring framework**가 더 정확한 설명입니다.
 
-### 검증 범위 참고
+보일러플레이트를 줄여주는 건 여전히 장점입니다. 하지만 실제로 팀에서 가치를 만드는 지점은, wiring이 커질수록 **문제가 나중이 아니라 빌드 시점에 드러난다**는 데 있습니다.
 
-기본 설정(`validate: true`)에서는 누락된 팩토리 등 주요 설정 문제가 컴파일 타임에 진단됩니다.  
-다만 `validate: false`로 완화하면 일부 누락 케이스는 런타임 `fatalError` fallback으로 처리될 수 있으므로, 보통은 기본값 사용을 권장드립니다.
+문서를 더 보고 싶다면 아래 순서가 가장 좋습니다.
 
----
-
-## 의존성 그래프 시각화
-
-InnoDI는 CLI 도구를 제공하여 의존성 그래프를 시각화할 수 있습니다.
-
-### Mermaid 다이어그램 생성
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project
-```
-
-```mermaid
-graph TD
-    A[AppContainer] --> B[apiClient]
-    A --> C[networkService]
-    B --> D[config]
-    C --> D
-```
-
-### Graphviz DOT 형식
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project --format dot --output graph.dot
-```
-
-### DAG 검증
-
-```bash
-swift run InnoDI-DependencyGraph --root /path/to/project --validate-dag
-```
-
-### Build Tool Plugin
-
-`Package.swift`에 플러그인을 추가하시면 빌드 시 자동 검증을 수행하실 수 있습니다.
-
-```swift
-.target(
-    name: "YourApp",
-    dependencies: ["InnoDI"],
-    plugins: [
-        .plugin(name: "InnoDIDAGValidationPlugin", package: "InnoDI")
-    ]
-)
-```
-
----
-
-## 실제 아키텍처 예시
-
-### 클린 아키텍처와 함께 사용하기
-
-```swift
-// Domain Layer
-protocol WeatherRepository {
-    func fetchWeather(city: String) async throws -> Weather
-}
-
-// Data Layer
-struct WeatherRepositoryImpl: WeatherRepository {
-    let apiClient: any APIClientProtocol
-    let cache: any CacheProtocol
-
-    func fetchWeather(city: String) async throws -> Weather {
-        // 구현
-    }
-}
-
-// Presentation Layer
-@MainActor
-@Observable
-class WeatherViewModel {
-    let repository: any WeatherRepository
-
-    init(repository: any WeatherRepository) {
-        self.repository = repository
-    }
-}
-
-// DI Container
-@DIContainer(mainActor: true)
-struct AppContainer {
-    // Configuration
-    @Provide(.input)
-    var baseURL: String
-
-    // Data Layer
-    @Provide(.shared, APIClient.self, with: [\.baseURL])
-    var apiClient: any APIClientProtocol
-
-    @Provide(.shared, factory: { MemoryCache() })
-    var cache: any CacheProtocol
-
-    // Repository
-    @Provide(.shared, WeatherRepositoryImpl.self, with: [\.apiClient, \.cache])
-    var weatherRepository: any WeatherRepository
-
-    // ViewModels (transient - 매번 새 인스턴스)
-    @Provide(.transient, WeatherViewModel.self, with: [\.weatherRepository], concrete: true)
-    var weatherViewModel: WeatherViewModel
-}
-
-// App 진입점
-@main
-struct WeatherApp: App {
-    let container = AppContainer(baseURL: "https://api.weather.com")
-
-    var body: some Scene {
-        WindowGroup {
-            WeatherView(viewModel: container.weatherViewModel)
-        }
-    }
-}
-```
-
----
-
-## 다른 라이브러리와 비교
-
-| 기능 | InnoDI | Swinject | Factory | 수동 |
-|------|--------|----------|---------|------|
-| 컴파일 타임 검증 | 강함 | 약함 | 일부 | 강함(직접 작성 시) |
-| 순환 참조 탐지 | 지원 | 제한적 | 제한적 | 수동 점검 필요 |
-| 보일러플레이트 | 적음 | 중간 | 적음 | 많음 |
-| 런타임 설정 오류 가능성 | 낮음(기본 설정 기준) | 있음 | 낮음 | 낮음 |
-| 학습 곡선 | 낮음~중간 | 중간 | 낮음 | 없음 |
-| SwiftUI 통합 | 용이 | 용이 | 용이 | 용이 |
-
----
-
-## 결론
-
-InnoDI는 **Swift Macro를 활용해 DI 설정 품질과 개발자 경험을 함께 개선하는 라이브러리**입니다.
-
-### 추천 대상
-
-- **클린 아키텍처**를 도입하는 프로젝트
-- **테스트 용이성**이 중요한 프로젝트
-- **런타임 설정 오류**를 줄이고 싶은 팀
-- **보일러플레이트**를 줄이고 싶은 개발자
-
-### InnoDI의 장점 요약
-
-1. **컴파일 타임 진단** - 주요 설정 오류를 조기에 확인할 수 있습니다.
-2. **자동 코드 생성** - 반복되는 초기화 코드를 줄일 수 있습니다.
-3. **프로토콜 우선 설계** - 테스트 가능한 구조를 유지하기 좋습니다.
-4. **간편한 Mock 주입** - Init Override로 테스트 코드를 단순화할 수 있습니다.
-5. **의존성 그래프 시각화** - 아키텍처 관계를 빠르게 파악할 수 있습니다.
-
----
-
-## 참고 자료
-
-- [InnoDI GitHub 저장소](https://github.com/InnoSquadCorp/InnoDI)
-- [Swift Macro 공식 문서](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros/)
-- [의존성 역전 원칙 (DIP)](https://en.wikipedia.org/wiki/Dependency_inversion_principle)
+1. [README](https://github.com/InnoSquadCorp/InnoDI)
+2. [`Validation.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/Validation.md)
+3. [`PolicyBoundaries.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md)
+4. [`ModuleWideInitDetection.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md)

--- a/_posts/2026-02-23-innonetwork-type-safe-networking-en.md
+++ b/_posts/2026-02-23-innonetwork-type-safe-networking-en.md
@@ -10,727 +10,329 @@ toc: true
 comments: true
 ---
 
-## Why was it made?
+## Introduction
 
+In the earlier versions of this post, I described `InnoNetwork` mostly as "a type-safe HTTP client built on Swift Concurrency." That is still true, but it no longer describes the full public surface of `3.0.1`.
 
-Similar concerns arise over and over again every time I write networking code on iOS.
+The package now exposes three distinct products:
 
-**URLSession code is verbose.** To send a request, you need to create a URL, set up a URLRequest, create a dataTask, check the response, and decode the JSON. In this process, you'll be writing the same boilerplate over and over again.
+- `InnoNetwork`
+- `InnoNetworkDownload`
+- `InnoNetworkWebSocket`
 
-**Error handling is inconsistent.** It's hard to tell if it's a 404, a server error, or a decoding failure, and code that treats everything as `catch { print(error) }` easily accumulates.
+And the public contract is no longer just about sending HTTP requests. It also includes **explicit configuration entry points, transport policy, event delivery, durability, and reconnect behavior**.
 
-**Lack of type safety.** Request parameters and response types are unclear, resulting in more code that overuses `Any` or uses forced casting.
+This post revisits `InnoNetwork` from that perspective.
 
-**Retry logic is complex.** Logic such as how to retry when the network is disconnected and how to apply exponential backoff can be easily mixed into business code.
+## Why revisit it now
 
-**InnoNetwork** was created to solve this problem. The core idea is simple.
+The important shift in `3.0.x` is not just "more examples." It is that the framework now has clearer operational boundaries:
 
-> Let’s define the API as a type and handle it neatly with Swift Concurrency.
+- `safeDefaults` is the recommended entry point
+- `advanced` is where operational tuning belongs
+- download and websocket lifecycle are separated into dedicated products
+- Protocol Buffers support moved into a separate `InnoNetworkProtobuf` package
+- bounded buffering, append-log durability, and reconnect taxonomy are now part of the documented runtime model
 
+So the right way to explain `InnoNetwork` today is not only "how to send a request," but **which network lifecycle belongs to which surface**.
 
----
+## Product structure and ownership boundary
 
-## Core Concepts
+It helps to start with the product split.
 
+### `InnoNetwork`
 
-### Three Principles
+This is the core request/response module.
 
+- `APIDefinition`
+- `MultipartAPIDefinition`
+- `DefaultNetworkClient`
+- `NetworkConfiguration`
+- `TrustPolicy`
+- `RetryPolicy`
 
-1. **Type Safety**: All API requests and responses are generic and strongly typed. You can catch type errors at compile time.
+### `InnoNetworkDownload`
 
-2. **Protocol-based**: Defines the API with the `APIDefinition` protocol. While providing a basic implementation, customization is free.
+This product owns download lifecycle.
 
-3. **Swift Concurrency**: Supports async/await, actor, and Sendable. You can escape callback hell.
+- `DownloadConfiguration`
+- `DownloadManager`
+- progress, completion, and failure streams
+- foreground and background orchestration
 
+### `InnoNetworkWebSocket`
 
-### Main Components
+This product owns connection-oriented realtime flows.
 
+- `WebSocketConfiguration`
+- `WebSocketManager`
+- reconnect behavior
+- heartbeat and pong timeout
+- event streams
 
-| component | role |
-|---------|------|
-| `APIDefinition` | Protocol that defines API requests |
-| `MultipartAPIDefinition` | Protocol for file upload |
-| `DefaultNetworkClient` | actor executing network requests |
-| `NetworkConfiguration` | Setting timeout, cache policy, retry policy, etc. |
-| `RequestInterceptor` | Pre-processing of requests (adding authentication tokens, etc.) |
-| `ResponseInterceptor` | Post-response processing |
-| `RetryPolicy` | Define retry logic |
+That separation is important. `InnoNetwork` is not one giant "network utility" module. It is a framework family that splits surfaces by transport lifecycle.
 
----
+## Install
 
-## Basic usage
-
-
-### API settings
-
-
-First, define the basic settings of the API.
+The base package installation for `3.0.1` starts here.
 
 ```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1")
+]
+```
+
+## Core request model
+
+The core modeling primitive is still `APIDefinition`.
+
+```swift
+import Foundation
 import InnoNetwork
 
-struct MyAPI: APIConfigure {
-    var host: String { "https://api.example.com" }
-    var basePath: String { "v1" }
-}
-```
-
-Just follow the `APIConfigure` protocol. `baseURL` is calculated automatically.
-
-### API Definition
-
-
-Each API endpoint is defined as a type.
-
-```swift
-struct GetUsers: APIDefinition {
-    typealias Parameter = EmptyParameter  // no request parameters
-    typealias APIResponse = [User]       // response type
-
-    var method: HTTPMethod { .get }
-    var path: String { "/users" }
-}
-
-struct CreateUser: APIDefinition {
-    struct UserParameter: Encodable, Sendable {
-        let name: String
-        let email: String
-    }
-
-    typealias Parameter = UserParameter
-    typealias APIResponse = User
-
-    var parameters: UserParameter?
-    var method: HTTPMethod { .post }
-    var path: String { "/users" }
-
-    init(name: String, email: String) {
-        self.parameters = UserParameter(name: name, email: email)
-    }
-}
-```
-
-Just follow the `APIDefinition` protocol. For the rest, default implementations are provided.
-
-### execute request
-
-
-```swift
-let client = try DefaultNetworkClient(configuration: MyAPI())
-
-// GET request
-let users = try await client.request(GetUsers())
-
-// POST request
-let newUser = try await client.request(CreateUser(name: "John Doe", email: "john@example.com"))
-```
-
-It's just three lines. Using `URLSession` directly usually takes 20+ lines.
-
----
-
-## HTTP method
-
-
-All standard HTTP methods are supported.
-
-```swift
-struct GetPost: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = Post
-
-    let postId: Int
-    var method: HTTPMethod { .get }
-    var path: String { "/posts/\(postId)" }
-}
-
-struct UpdatePost: APIDefinition {
-    struct PostParameter: Encodable, Sendable {
-        let title: String
-        let body: String
-    }
-
-    typealias Parameter = PostParameter
-    typealias APIResponse = Post
-
-    var parameters: PostParameter?
-    var method: HTTPMethod { .put }
-    var path: String { "/posts/1" }
-}
-
-struct PatchPost: APIDefinition {
-    struct PatchParameter: Encodable, Sendable {
-        let title: String?
-    }
-
-    typealias Parameter = PatchParameter
-    typealias APIResponse = Post
-
-    var parameters: PatchParameter?
-    var method: HTTPMethod { .patch }
-    var path: String { "/posts/1" }
-}
-
-struct DeletePost: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = EmptyResponse  // no response body
-
-    let postId: Int
-    var method: HTTPMethod { .delete }
-    var path: String { "/posts/\(postId)" }
-}
-```
-
----
-
-## custom header
-
-
-Header customization such as authentication and content type can be easily applied.
-
-```swift
-struct GetPrivateData: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = PrivateData
-
-    var method: HTTPMethod { .get }
-    var path: String { "/private" }
-
-    var headers: HTTPHeaders {
-        var headers = HTTPHeaders.default
-        headers.add(.authorization(bearerToken: "my-jwt-token"))
-        headers.add(.accept("application/json"))
-        headers.add(name: "X-API-Version", value: "2")
-        return headers
-    }
-}
-```
-
-### default header
-
-
-```swift
-HTTPHeaders.default  // default headers (Content-Type, Accept, etc.)
-```
-
-### Available header types
-
-
-```swift
-.authorization(username: "user", password: "pass")  // Basic Auth
-.authorization(bearerToken: "token")                // Bearer Token
-.contentType("application/json")
-.accept("application/json")
-.acceptLanguage("ko-KR")
-.userAgent("MyApp/1.0")
-HTTPHeader(name: "X-Custom-Header", value: "value")
-```
-
----
-
-## Content type
-
-
-In addition to JSON, it supports various content types.
-
-### JSON (default)
-
-
-```swift
-struct CreatePost: APIDefinition {
-    var contentType: ContentType { .json }  // default
-    // ...
-}
-```
-
-### Form URL-Encoded
-
-
-```swift
-struct LoginRequest: APIDefinition {
-    struct LoginParameter: Encodable, Sendable {
-        let email: String
-        let password: String
-    }
-
-    typealias Parameter = LoginParameter
-    typealias APIResponse = AuthResponse
-
-    var parameters: LoginParameter?
-    var method: HTTPMethod { .post }
-    var path: String { "/login" }
-    var contentType: ContentType { .formUrlEncoded }  // x-www-form-urlencoded
-
-    init(email: String, password: String) {
-        self.parameters = LoginParameter(email: email, password: password)
-    }
-}
-```
-
----
-
-## File Upload (Multipart)
-
-
-File upload uses `MultipartAPIDefinition`.
-
-```swift
-struct UploadImage: MultipartAPIDefinition {
-    typealias APIResponse = UploadResponse
-
-    let imageData: Data
-    let title: String
-
-    var multipartFormData: MultipartFormData {
-        var formData = MultipartFormData()
-        formData.append(title, name: "title")
-        formData.append(
-            imageData,
-            name: "file",
-            fileName: "image.jpg",
-            mimeType: "image/jpeg"
-        )
-        return formData
-    }
-
-    var method: HTTPMethod { .post }
-    var path: String { "/upload" }
-}
-
-// usage
-let response = try await client.upload(UploadImage(imageData: data, title: "Profile Photo"))
-```
-
-You can do this by using the `upload` method.
-
----
-
-## Error handling
-
-
-All network errors are systematically handled with the `NetworkError` enumeration.
-
-```swift
-do {
-    let user = try await client.request(GetUser(id: 1))
-    print("User: \(user.name)")
-} catch let error as NetworkError {
-    switch error {
-    case .statusCode(let response):
-        // HTTP status errors (404, 500, etc.)
-        print("HTTP error: \(response.statusCode)")
-        if response.statusCode == 401 {
-            // handle expired authentication
-        }
-    case .objectMapping(let decodingError, let response):
-        // JSON decoding failure
-        print("Decoding failed: \(decodingError.message)")
-    case .invalidBaseURL(let url):
-        print("Invalid URL: \(url)")
-    case .underlying(let underlyingError, _):
-        // network connectivity failure, etc.
-        print("Other error: \(underlyingError.message)")
-    case .cancelled:
-        // request cancelled
-        print("Request cancelled")
-    default:
-        print("Unknown error: \(error)")
-    }
-}
-```
-
-### NetworkError type
-
-
-| case | meaning |
-|-------|------|
-| `invalidBaseURL` | Invalid base URL |
-| `invalidRequestConfiguration` | Invalid request settings |
-| `statusCode` | HTTP status code errors (other than 200-299) |
-| `objectMapping` | JSON decoding failed |
-| `jsonMapping` | JSON parsing failed |
-| `underlying` | Other errors |
-| `trustEvaluationFailed` | SSL certificate verification failed |
-| `cancelled` | Cancel request |
-
----
-
-## Retry Policy
-
-
-Supports automatic retry in case of network failure.
-
-```swift
-let retryPolicy = ExponentialBackoffRetryPolicy(
-    maxRetries: 3,              // maximum retry count
-    retryDelay: 1.0,            // base delay (seconds)
-    maxDelay: 30.0,             // maximum delay
-    jitterRatio: 0.2,           // jitter (±20%)
-    waitsForNetworkChanges: true, // wait for network changes
-    networkChangeTimeout: 10.0   // max wait for network change
-)
-
-let config = NetworkConfiguration(
-    baseURL: URL(string: "https://api.example.com/v1")!,
-    retryPolicy: retryPolicy
-)
-
-let client = try DefaultNetworkClient(
-    configuration: MyAPI(),
-    networkConfiguration: config
-)
-```
-
-### Exponential backoff
-
-
-`ExponentialBackoffRetryPolicy` automatically applies exponential backoff.
-
-- 1st retry: wait ~1 second
-
-- 2nd retry: wait ~2 seconds
-
-- 3rd retry: wait ~4 seconds
-
-
-Add jitter to distribute server load.
-
-### Retry conditions
-
-
-By default, it retries in the following cases:
-
-- 408 Request Timeout
-
-- 429 Too Many Requests
-
-- 5xx server error
-
-- Network connection failure
-
-
----
-
-## interceptor
-
-
-Requests/responses can be intercepted and processed.
-
-### RequestInterceptor
-
-
-Add or modify headers before sending the request.
-
-```swift
-struct AuthInterceptor: RequestInterceptor {
-    let tokenProvider: () -> String?
-
-    func adapt(_ urlRequest: URLRequest) async throws -> URLRequest {
-        var request = urlRequest
-        if let token = tokenProvider() {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        return request
-    }
-}
-
-struct RefreshTokenAPI: APIDefinition {
-    // ...
-    var requestInterceptors: [RequestInterceptor] {
-        [AuthInterceptor(tokenProvider: { TokenStorage.shared.accessToken })]
-    }
-}
-```
-
-### ResponseInterceptor
-
-
-After receiving the response, the data is processed.
-
-```swift
-struct ErrorResponseInterceptor: ResponseInterceptor {
-    func adapt(_ urlResponse: Response, request: URLRequest) async throws -> Response {
-        // parse message from error responses
-        if urlResponse.statusCode >= 400 {
-            // error logging
-        }
-        return urlResponse
-    }
-}
-```
-
----
-
-## network monitoring
-
-
-Changes in network status can be detected.
-
-```swift
-let monitor = NetworkMonitor.shared
-
-// inspect current status
-let snapshot = await monitor.currentSnapshot()
-print("Connected: \(snapshot.status == .satisfied)")
-print("Interfaces: \(snapshot.interfaceTypes)")
-
-// wait for network changes
-let newSnapshot = await monitor.waitForChange(from: snapshot, timeout: 30.0)
-```
-
-### NetworkSnapshot
-
-
-```swift
-struct NetworkSnapshot: Sendable {
-    let status: NetworkReachabilityStatus      // .satisfied, .unsatisfied, .requiresConnection
-    let interfaceTypes: Set<NetworkInterfaceType>  // .wifi, .cellular, .wiredEthernet, etc.
-}
-```
-
----
-
-## event observer
-
-
-You can observe network events.
-
-```swift
-struct LoggingObserver: NetworkEventObserving {
-    func handle(_ event: NetworkEvent) {
-        switch event {
-        case .requestStart(let requestID, let method, let url, let retryIndex):
-            print("[\(requestID)] \(method) \(url)")
-        case .responseReceived(let requestID, let statusCode, let byteCount):
-            print("[\(requestID)] Response: \(statusCode), \(byteCount) bytes")
-        case .requestFinished(let requestID, let statusCode, let byteCount):
-            print("[\(requestID)] Completed: \(statusCode)")
-        case .requestFailed(let requestID, let errorCode, let message):
-            print("[\(requestID)] Failed: \(message)")
-        case .retryScheduled(let requestID, let retryIndex, let delay, let reason):
-            print("[\(requestID)] Retry \(retryIndex + 1) scheduled in \(delay)s")
-        default:
-            break
-        }
-    }
-}
-
-let config = NetworkConfiguration(
-    baseURL: URL(string: "https://api.example.com")!,
-    eventObservers: [LoggingObserver()]
-)
-```
-
-### NetworkEvent Type
-
-
-| event | point of view |
-|-------|------|
-| `requestStart` | Start request |
-| `requestAdapted` | After applying the interceptor |
-| `responseReceived` | Receive response |
-| `requestFinished` | Request completed |
-| `requestFailed` | request failed |
-| `retryScheduled` | Schedule a retry |
-
----
-
-## Protobuf support
-
-
-Protocol Buffers are also supported.
-
-```swift
-import SwiftProtobuf
-
-struct GetProtobufData: ProtobufAPIDefinition {
-    typealias Parameter = MyRequestProto  // Protobuf message
-    typealias APIResponse = MyResponseProto
-
-    var parameters: MyRequestProto?
-    var method: HTTPMethod { .post }
-    var path: String { "/data" }
-}
-
-let response = try await client.protobufRequest(GetProtobufData(...))
-```
-
----
-
-## Real architecture example
-
-
-### With the Repository layer
-
-
-```swift
-// Domain
 struct User: Decodable, Sendable {
     let id: Int
     let name: String
-    let email: String
 }
 
-protocol UserRepository {
-    func fetchUsers() async throws -> [User]
-    func createUser(name: String, email: String) async throws -> User
-}
+struct GetUser: APIDefinition {
+    typealias Parameter = EmptyParameter
+    typealias APIResponse = User
 
-// Data
-final class UserRepositoryImpl: UserRepository {
-    private let client: DefaultNetworkClient
-
-    init(client: DefaultNetworkClient) {
-        self.client = client
-    }
-
-    func fetchUsers() async throws -> [User] {
-        try await client.request(GetUsers())
-    }
-
-    func createUser(name: String, email: String) async throws -> User {
-        try await client.request(CreateUser(name: name, email: email))
-    }
-}
-
-// App
-@main
-struct MyApp: App {
-    let client: DefaultNetworkClient
-    let userRepository: UserRepository
-
-    init() {
-        do {
-            self.client = try DefaultNetworkClient(configuration: MyAPI())
-        } catch {
-            fatalError("Failed to create DefaultNetworkClient: \(error)")
-        }
-        self.userRepository = UserRepositoryImpl(client: client)
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            UserListView(repository: userRepository)
-        }
-    }
+    var method: HTTPMethod { .get }
+    var path: String { "/users/1" }
 }
 ```
 
-API definition and business logic are neatly separated.
-
----
-
-## Download (InnoNetworkDownload)
-
-
-Downloading large files uses a separate module.
+Execution goes through `DefaultNetworkClient`.
 
 ```swift
+let client = DefaultNetworkClient(
+    configuration: .safeDefaults(
+        baseURL: URL(string: "https://api.example.com/v1")!
+    )
+)
+
+let user = try await client.request(GetUser())
+print(user.name)
+```
+
+One meaningful change from older examples is that `APIConfigure` is no longer the main entry point for configuration in the docs. In `3.0.x`, the dominant style is **explicit configuration objects**.
+
+## `safeDefaults` and `advanced`
+
+The strongest message in the current documentation is simple:
+
+> stay on `safeDefaults` unless you have a real operational reason to tune behavior
+
+### Recommended starting point
+
+```swift
+let client = DefaultNetworkClient(
+    configuration: NetworkConfiguration.safeDefaults(
+        baseURL: URL(string: "https://api.example.com")!
+    )
+)
+```
+
+### Move to `advanced` only when needed
+
+```swift
+let configuration = NetworkConfiguration.advanced(
+    baseURL: URL(string: "https://api.example.com")!
+) { builder in
+    builder.timeout = 30
+    builder.retryPolicy = ExponentialBackoffRetryPolicy()
+    builder.trustPolicy = .systemDefault
+}
+
+let client = DefaultNetworkClient(configuration: configuration)
+```
+
+That distinction matters because `advanced` is public and supported, but its tuning values are not the main compatibility story. The recommended public path is still `safeDefaults`.
+
+## Transport and operational surface
+
+To understand `InnoNetwork 3.x`, request and response modeling is only one part of the story.
+
+### `RetryPolicy`
+
+Retry behavior is isolated into policy rather than leaking into business logic.
+
+- `RetryPolicy`
+- `ExponentialBackoffRetryPolicy`
+
+### `TrustPolicy`
+
+Trust evaluation is also an explicit public surface.
+
+- `.systemDefault`
+- public key pinning
+
+### `EventDeliveryPolicy`
+
+This is one of the clearest signs of the `3.x` direction. Event delivery is not treated as an unbounded implementation detail. It is modeled as a bounded buffering policy with overflow behavior that can be tuned explicitly.
+
+That means the framework gives you a public way to talk about what should happen when event streams start backing up under load.
+
+### `URLQueryEncoder` and `AnyResponseDecoder`
+
+The documentation also makes encoding and decoding behavior more explicit than before.
+
+- `URLQueryEncoder` is the public surface behind deterministic query and form encoding.
+- `AnyResponseDecoder` is one of the public pieces used for explicit decoding strategies.
+
+You may not touch these types every day, but they are still part of the public `3.x` contract and worth naming explicitly.
+
+## Interceptors and request/response policy
+
+Earlier versions of this post made `RequestInterceptor`, `ResponseInterceptor`, and `RetryPolicy` sound like the whole framework. In `3.x`, the tone should be slightly different.
+
+These types still matter:
+
+- `RequestInterceptor`
+- `ResponseInterceptor`
+- `RetryPolicy`
+
+But the more important story is that **request execution happens inside explicit policy boundaries**.
+
+The README and changelog make it clear that request/response execution was reorganized around internal transport policies and explicit decoding strategies. That is essential to the implementation, but in a blog post it is better framed as runtime architecture rather than a stable public contract.
+
+## Download lifecycle
+
+Download behavior belongs to `InnoNetworkDownload`.
+
+```swift
+import Foundation
 import InnoNetworkDownload
 
 let manager = DownloadManager.shared
-
-// start download
 let task = await manager.download(
-    url: URL(string: "https://example.com/large-file.zip")!,
-    toDirectory: documentsDirectory
+    url: URL(string: "https://example.com/file.zip")!,
+    toDirectory: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
 )
 
-// monitor progress (AsyncSequence)
-for await event in manager.events(for: task) {
-    switch event {
-    case .progress(let progress):
-        print("Progress: \(progress.percentCompleted)%")
-        print("Bytes received: \(progress.bytesReceived)")
-    case .completed(let url):
-        print("Completed: \(url)")
-    case .failed(let error):
-        print("Failed: \(error)")
-    case .paused:
-        print("Paused")
-    case .resumed:
-        print("Resumed")
-    }
+for await event in await manager.events(for: task) {
+    print(event)
 }
-
-// pause/resume
-await manager.pause(task)
-await manager.resume(task)
 ```
 
-Supports background downloads and resumable downloads.
+The important part is not just "it downloads files." The product is designed around:
 
----
+- foreground and background orchestration
+- pause, resume, and retry
+- listener retention
+- append-log persistence for durability
 
-## Problems InnoNetwork Solve
+So `DownloadManager` is better understood as a **download lifecycle manager** than as a convenience wrapper around `URLSessionDownloadTask`.
 
+You can also move to explicit configuration when needed.
 
-| problem | How to solve |
-|------|----------|
-| URLSession Long-winded code | Simplified with `APIDefinition` protocol |
-| Lack of type safety | Request/response strongly typed with generics |
-| Error handling unclear | Systematized as `NetworkError` enumeration |
-| Complex retry logic | Abstracted with `RetryPolicy` protocol |
-| callback hell | async/await based |
-| Interceptor implementation hassle | `RequestInterceptor`, `ResponseInterceptor` protocol |
-| Difficulty tracking network status | `NetworkMonitor`, event observer |
+```swift
+let configuration = DownloadConfiguration.advanced { builder in
+    builder.maxConnectionsPerHost = 3
+    builder.maxRetryCount = 2
+}
+```
 
----
+Again, the pattern is the same: `safeDefaults` first, `advanced` only for concrete tuning needs.
 
-## Requirements
+## WebSocket lifecycle
 
+Realtime connection behavior belongs to `InnoNetworkWebSocket`.
 
-- iOS 26+ / macOS 14+ / tvOS 26+ / watchOS 26+ / visionOS 26+
+```swift
+import Foundation
+import InnoNetworkWebSocket
 
-- Swift 6.2+
+let task = await WebSocketManager.shared.connect(
+    url: URL(string: "wss://echo.example.com/socket")!
+)
 
+for await event in await WebSocketManager.shared.events(for: task) {
+    print(event)
+}
+```
 
-Supports strict concurrency in Swift 6. `DefaultNetworkClient` is implemented as `actor`, and the main type conforms to `Sendable`.
+The main value here is not just connect/send/receive. It is the operational model around:
 
----
+- reconnect policy
+- handshake-aware close taxonomy
+- reconnect suppression rules
+- heartbeat and pong timeout
+- event delivery policy
 
-## Conclusion
+So when explaining `WebSocketManager`, it is more accurate to focus on **how it manages failure and reconnect behavior** than on the bare existence of a websocket client.
 
+## Error handling
 
-InnoNetwork is a type-safe, native Swift Concurrency networking framework.
+`InnoNetwork` favors explicit transport errors over opaque failure buckets.
 
-### When recommended
+```swift
+do {
+    let user = try await client.request(GetUser())
+    print(user)
+} catch let error as NetworkError {
+    switch error {
+    case .invalidBaseURL(let url):
+        print("Invalid base URL: \(url)")
+    case .invalidRequestConfiguration(let message):
+        print("Invalid request configuration: \(message)")
+    case .statusCode(let response):
+        print("Unexpected status code: \(response.statusCode)")
+    case .objectMapping(let underlying, _):
+        print("Decoding failed: \(underlying)")
+    case .trustEvaluationFailed(let reason):
+        print("Trust evaluation failed: \(reason)")
+    case .cancelled:
+        print("Request cancelled")
+    default:
+        print(error)
+    }
+}
+```
 
+`invalidRequestConfiguration` is especially useful because it usually means the request shape and policy do not agree. That is much more actionable than an opaque generic failure.
 
-- When you want to neatly organize your API request code
+## Protocol Buffers are now a separate package
 
-- When you want to ensure type safety
+Older versions of this post treated Protocol Buffers support as if it were still part of the main package surface. That is no longer accurate in `3.0.1`.
 
-- When you want to structurally handle retries, interceptors, etc.
+If you need protobuf request/response support, you now add **`InnoNetworkProtobuf` as a separate package**.
 
-- When working in a Swift 6 strict concurrency environment
+```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetworkProtobuf.git", branch: "main")
+]
+```
 
+That is best read as a clearer architectural split between the core transport package and the protobuf adapter layer, not as a missing feature.
 
-### Summary of Benefits
+## When to use which surface
 
+| Situation | Recommended choice |
+|------|------|
+| standard REST or HTTP APIs | `InnoNetwork` + `NetworkConfiguration.safeDefaults(baseURL:)` |
+| retry, trust, metrics, or event delivery tuning | `NetworkConfiguration.advanced(baseURL:_:)` |
+| file download with lifecycle tracking | `InnoNetworkDownload` + `DownloadManager` |
+| realtime connection with reconnect and heartbeat requirements | `InnoNetworkWebSocket` + `WebSocketManager` |
+| protobuf request or response modeling | `InnoNetwork` + `InnoNetworkProtobuf` |
 
-1. **Type safety** - request/response strongly typed with generics
+## Closing thoughts
 
-2. **Concise API** - Protocol-based definition, default implementation provided
+If I had to summarize `InnoNetwork 3.0.1` in one sentence, I would no longer call it only a type-safe HTTP client. A better description is **a networking framework family with explicit operational policy**.
 
-3. **Swift Concurrency** - fully supports async/await, actor
+`APIDefinition` and `DefaultNetworkClient` are still the starting point. But to use `3.x` well, it helps to keep four things in view:
 
-4. **Retry Policy** - exponential backoff, network change detection
+- `safeDefaults` is the default path
+- `advanced` is for local operational tuning
+- download and websocket lifecycle belong to separate products
+- protobuf support now lives in a separate package
 
-5. **Interceptor** - Intercept requests/responses
+For a deeper look, I recommend reading these in order:
 
-6. **Event Observation** - Logging, Analysis, Monitoring
-
-7. **Swift 6 ready** - Full support for Sendable and actor
-
-
----
-
-## Reference Materials
-
-
-- [InnoNetwork GitHub Repository](https://github.com/InnoSquadCorp/InnoNetwork)
-
-- [Swift Concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
-
-- [URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+1. [README](https://github.com/InnoSquadCorp/InnoNetwork)
+2. [`API_STABILITY.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/API_STABILITY.md)
+3. [`Examples/README.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/Examples/README.md)
+4. [`docs/releases/3.0.1.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/docs/releases/3.0.1.md)

--- a/_posts/2026-02-23-innonetwork-type-safe-networking.md
+++ b/_posts/2026-02-23-innonetwork-type-safe-networking.md
@@ -10,663 +10,327 @@ toc: true
 comments: true
 ---
 
-## 왜 만들었을까요?
+## 들어가며
 
-iOS에서 네트워킹 코드를 작성할 때마다 비슷한 고민이 반복됩니다.
+초기 버전의 `InnoNetwork`를 설명할 때는 보통 "Swift Concurrency 기반 타입 안전 HTTP 클라이언트"라는 표현을 썼습니다. 지금도 틀린 말은 아니지만, `3.0.1` 기준으로는 그 설명만으로 부족합니다.
 
-**URLSession 코드가 장황합니다.** 요청 하나를 보내려면 URL을 만들고, URLRequest를 설정하고, dataTask를 만들고, response를 체크하고, JSON을 디코딩해야 합니다. 이 과정에서 같은 보일러플레이트를 반복해서 작성하게 됩니다.
+현재 공개 패키지는 아래 세 제품으로 나뉩니다.
 
-**에러 처리가 일관되지 않습니다.** 404인지, 서버 에러인지, 디코딩 실패인지 구분하기 어렵고, 모든 것을 `catch { print(error) }`로 처리하는 코드가 쉽게 누적됩니다.
+- `InnoNetwork`
+- `InnoNetworkDownload`
+- `InnoNetworkWebSocket`
 
-**타입 안전성이 부족합니다.** 요청 파라미터와 응답 타입이 명확하지 않아서 `Any`를 남발하거나 강제 캐스팅을 사용하는 코드가 늘어납니다.
+그리고 실제 public contract는 단순 HTTP wrapper가 아니라, **명시적인 configuration entry point, transport policy, event delivery, durability, reconnect model**까지 포함합니다.
 
-**재시도 로직이 복잡합니다.** 네트워크가 끊겼을 때 재시도는 어떻게 할지, 지수 백오프는 어떻게 적용할지 같은 로직이 비즈니스 코드에 쉽게 섞입니다.
+이 글은 그 기준으로 `InnoNetwork`를 다시 정리합니다.
 
-**InnoNetwork**는 이런 문제를 해결하기 위해 만들었습니다. 핵심 아이디어는 단순합니다.
+## 왜 다시 봐야 하나
 
-> API를 타입으로 정의하고, Swift Concurrency로 깔끔하게 처리해 보겠습니다.
+`3.0.x`에서 가장 중요한 변화는 "더 많은 endpoint 예제"가 아닙니다. 대신 아래 관점이 또렷해졌습니다.
 
----
+- `safeDefaults`가 권장 진입점이라는 점
+- `advanced` builder로 운영 정책을 국소적으로 조정한다는 점
+- 다운로드와 웹소켓이 별도 product로 분리되어 있다는 점
+- protobuf가 별도 패키지 `InnoNetworkProtobuf`로 이동했다는 점
+- bounded buffering, append-log durability, reconnect taxonomy 같은 운영 모델이 문서화되었다는 점
 
-## 핵심 개념
+즉, 지금 `InnoNetwork`는 "HTTP 요청 보내는 법"보다 **어떤 네트워크 lifecycle을 어떤 surface로 다룰 것인지**가 더 중요한 프레임워크입니다.
 
-### 세 가지 원칙
+## 제품군 구조와 ownership boundary
 
-1. **타입 안전**: 모든 API 요청과 응답을 제네릭으로 강타입 처리합니다. 컴파일 타임에 타입 오류를 잡을 수 있습니다.
-2. **프로토콜 기반**: `APIDefinition` 프로토콜로 API를 정의합니다. 기본 구현을 제공하면서도 커스터마이징이 자유롭습니다.
-3. **Swift Concurrency**: async/await, actor, Sendable을 지원합니다. 콜백 지옥에서 벗어날 수 있습니다.
+먼저 제품 경계를 명확히 보는 게 좋습니다.
 
-### 주요 컴포넌트
+### `InnoNetwork`
 
-| 컴포넌트 | 역할 |
-|---------|------|
-| `APIDefinition` | API 요청을 정의하는 프로토콜 |
-| `MultipartAPIDefinition` | 파일 업로드용 프로토콜 |
-| `DefaultNetworkClient` | 네트워크 요청을 실행하는 actor |
-| `NetworkConfiguration` | 타임아웃, 캐시 정책, 재시도 정책 등 설정 |
-| `RequestInterceptor` | 요청 전 처리 (인증 토큰 추가 등) |
-| `ResponseInterceptor` | 응답 후 처리 |
-| `RetryPolicy` | 재시도 로직 정의 |
+기본 request/response API를 담당합니다.
 
----
+- `APIDefinition`
+- `MultipartAPIDefinition`
+- `DefaultNetworkClient`
+- `NetworkConfiguration`
+- `TrustPolicy`
+- `RetryPolicy`
 
-## 기본 사용법
+### `InnoNetworkDownload`
 
-### API 설정
+다운로드 lifecycle을 담당합니다.
 
-먼저 API의 기본 설정을 정의한다.
+- `DownloadConfiguration`
+- `DownloadManager`
+- progress / completion / failure event stream
+- foreground / background orchestration
+
+### `InnoNetworkWebSocket`
+
+연결 지향 realtime flow를 담당합니다.
+
+- `WebSocketConfiguration`
+- `WebSocketManager`
+- reconnect policy
+- heartbeat / pong timeout
+- event stream
+
+이 구조 덕분에 `InnoNetwork`는 "모든 네트워크 문제를 하나의 클라이언트에 우겨 넣는 패키지"가 아니라, transport 성격에 따라 surface를 분리한 프레임워크 제품군이 됩니다.
+
+## 설치
+
+기본 설치는 `3.0.1` 기준으로 아래처럼 시작합니다.
 
 ```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1")
+]
+```
+
+## Core Request Model
+
+기본 요청 모델은 여전히 `APIDefinition`입니다.
+
+```swift
+import Foundation
 import InnoNetwork
 
-struct MyAPI: APIConfigure {
-    var host: String { "https://api.example.com" }
-    var basePath: String { "v1" }
-}
-```
-
-`APIConfigure` 프로토콜을 따르면 된다. `baseURL`은 자동으로 계산된다.
-
-### API 정의
-
-각 API 엔드포인트를 타입으로 정의한다.
-
-```swift
-struct GetUsers: APIDefinition {
-    typealias Parameter = EmptyParameter  // 요청 파라미터 없음
-    typealias APIResponse = [User]       // 응답 타입
-
-    var method: HTTPMethod { .get }
-    var path: String { "/users" }
-}
-
-struct CreateUser: APIDefinition {
-    struct UserParameter: Encodable, Sendable {
-        let name: String
-        let email: String
-    }
-
-    typealias Parameter = UserParameter
-    typealias APIResponse = User
-
-    var parameters: UserParameter?
-    var method: HTTPMethod { .post }
-    var path: String { "/users" }
-
-    init(name: String, email: String) {
-        self.parameters = UserParameter(name: name, email: email)
-    }
-}
-```
-
-`APIDefinition` 프로토콜만 따르면 된다. 나머지는 기본 구현이 제공된다.
-
-### 요청 실행
-
-```swift
-let client = try DefaultNetworkClient(configuration: MyAPI())
-
-// GET 요청
-let users = try await client.request(GetUsers())
-
-// POST 요청
-let newUser = try await client.request(CreateUser(name: "홍길동", email: "hong@example.com"))
-```
-
-단 세 줄이다. URLSession을 직접 쓰면 최소 20줄은 될 코드다.
-
----
-
-## HTTP 메서드
-
-모든 표준 HTTP 메서드를 지원한다.
-
-```swift
-struct GetPost: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = Post
-
-    let postId: Int
-    var method: HTTPMethod { .get }
-    var path: String { "/posts/\(postId)" }
-}
-
-struct UpdatePost: APIDefinition {
-    struct PostParameter: Encodable, Sendable {
-        let title: String
-        let body: String
-    }
-
-    typealias Parameter = PostParameter
-    typealias APIResponse = Post
-
-    var parameters: PostParameter?
-    var method: HTTPMethod { .put }
-    var path: String { "/posts/1" }
-}
-
-struct PatchPost: APIDefinition {
-    struct PatchParameter: Encodable, Sendable {
-        let title: String?
-    }
-
-    typealias Parameter = PatchParameter
-    typealias APIResponse = Post
-
-    var parameters: PatchParameter?
-    var method: HTTPMethod { .patch }
-    var path: String { "/posts/1" }
-}
-
-struct DeletePost: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = EmptyResponse  // 응답 본문 없음
-
-    let postId: Int
-    var method: HTTPMethod { .delete }
-    var path: String { "/posts/\(postId)" }
-}
-```
-
----
-
-## 커스텀 헤더
-
-인증, 컨텐츠 타입 등 헤더 커스터마이징을 쉽게 적용할 수 있습니다.
-
-```swift
-struct GetPrivateData: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = PrivateData
-
-    var method: HTTPMethod { .get }
-    var path: String { "/private" }
-
-    var headers: HTTPHeaders {
-        var headers = HTTPHeaders.default
-        headers.add(.authorization(bearerToken: "my-jwt-token"))
-        headers.add(.accept("application/json"))
-        headers.add(name: "X-API-Version", value: "2")
-        return headers
-    }
-}
-```
-
-### 기본 헤더
-
-```swift
-HTTPHeaders.default  // Content-Type, Accept 등 기본 헤더
-```
-
-### 사용 가능한 헤더 타입
-
-```swift
-.authorization(username: "user", password: "pass")  // Basic Auth
-.authorization(bearerToken: "token")                // Bearer Token
-.contentType("application/json")
-.accept("application/json")
-.acceptLanguage("ko-KR")
-.userAgent("MyApp/1.0")
-HTTPHeader(name: "X-Custom-Header", value: "value")
-```
-
----
-
-## 컨텐츠 타입
-
-JSON 외에도 다양한 컨텐츠 타입을 지원한다.
-
-### JSON (기본)
-
-```swift
-struct CreatePost: APIDefinition {
-    var contentType: ContentType { .json }  // 기본값
-    // ...
-}
-```
-
-### Form URL-Encoded
-
-```swift
-struct LoginRequest: APIDefinition {
-    struct LoginParameter: Encodable, Sendable {
-        let email: String
-        let password: String
-    }
-
-    typealias Parameter = LoginParameter
-    typealias APIResponse = AuthResponse
-
-    var parameters: LoginParameter?
-    var method: HTTPMethod { .post }
-    var path: String { "/login" }
-    var contentType: ContentType { .formUrlEncoded }  // x-www-form-urlencoded
-
-    init(email: String, password: String) {
-        self.parameters = LoginParameter(email: email, password: password)
-    }
-}
-```
-
----
-
-## 파일 업로드 (Multipart)
-
-파일 업로드는 `MultipartAPIDefinition`을 사용합니다.
-
-```swift
-struct UploadImage: MultipartAPIDefinition {
-    typealias APIResponse = UploadResponse
-
-    let imageData: Data
-    let title: String
-
-    var multipartFormData: MultipartFormData {
-        var formData = MultipartFormData()
-        formData.append(title, name: "title")
-        formData.append(
-            imageData,
-            name: "file",
-            fileName: "image.jpg",
-            mimeType: "image/jpeg"
-        )
-        return formData
-    }
-
-    var method: HTTPMethod { .post }
-    var path: String { "/upload" }
-}
-
-// 사용
-let response = try await client.upload(UploadImage(imageData: data, title: "프로필 사진"))
-```
-
-`upload` 메서드를 사용하면 됩니다.
-
----
-
-## 에러 처리
-
-`NetworkError` 열거형으로 모든 네트워크 에러를 체계적으로 처리한다.
-
-```swift
-do {
-    let user = try await client.request(GetUser(id: 1))
-    print("사용자: \(user.name)")
-} catch let error as NetworkError {
-    switch error {
-    case .statusCode(let response):
-        // HTTP 상태 코드 에러 (404, 500 등)
-        print("HTTP 에러: \(response.statusCode)")
-        if response.statusCode == 401 {
-            // 인증 만료 처리
-        }
-    case .objectMapping(let decodingError, let response):
-        // JSON 디코딩 실패
-        print("디코딩 실패: \(decodingError.message)")
-    case .invalidBaseURL(let url):
-        print("잘못된 URL: \(url)")
-    case .underlying(let underlyingError, _):
-        // 네트워크 연결 실패 등
-        print("기타 에러: \(underlyingError.message)")
-    case .cancelled:
-        // 요청 취소
-        print("요청이 취소됨")
-    default:
-        print("알 수 없는 에러: \(error)")
-    }
-}
-```
-
-### NetworkError 종류
-
-| 케이스 | 의미 |
-|-------|------|
-| `invalidBaseURL` | 잘못된 베이스 URL |
-| `invalidRequestConfiguration` | 잘못된 요청 설정 |
-| `statusCode` | HTTP 상태 코드 에러 (200-299 외) |
-| `objectMapping` | JSON 디코딩 실패 |
-| `jsonMapping` | JSON 파싱 실패 |
-| `underlying` | 기타 에러 |
-| `trustEvaluationFailed` | SSL 인증서 검증 실패 |
-| `cancelled` | 요청 취소 |
-
----
-
-## 재시도 정책
-
-네트워크 실패 시 자동 재시도를 지원한다.
-
-```swift
-let retryPolicy = ExponentialBackoffRetryPolicy(
-    maxRetries: 3,              // 최대 재시도 횟수
-    retryDelay: 1.0,            // 기본 대기 시간 (초)
-    maxDelay: 30.0,             // 최대 대기 시간
-    jitterRatio: 0.2,           // 지터 (±20%)
-    waitsForNetworkChanges: true, // 네트워크 변경 대기
-    networkChangeTimeout: 10.0   // 네트워크 변경 대기 최대 시간
-)
-
-let config = NetworkConfiguration(
-    baseURL: URL(string: "https://api.example.com/v1")!,
-    retryPolicy: retryPolicy
-)
-
-let client = try DefaultNetworkClient(
-    configuration: MyAPI(),
-    networkConfiguration: config
-)
-```
-
-### 지수 백오프
-
-`ExponentialBackoffRetryPolicy`는 지수 백오프를 자동으로 적용한다.
-
-- 1차 재시도: ~1초 대기
-- 2차 재시도: ~2초 대기
-- 3차 재시도: ~4초 대기
-
-지터(jitter)를 추가해서 서버 부하를 분산시킨다.
-
-### 재시도 조건
-
-기본적으로 다음 경우에 재시도한다:
-
-- 408 Request Timeout
-- 429 Too Many Requests
-- 5xx 서버 에러
-- 네트워크 연결 실패
-
----
-
-## 인터셉터
-
-요청/응답을 가로채서 처리할 수 있다.
-
-### RequestInterceptor
-
-요청 보내기 전에 헤더를 추가하거나 수정한다.
-
-```swift
-struct AuthInterceptor: RequestInterceptor {
-    let tokenProvider: () -> String?
-
-    func adapt(_ urlRequest: URLRequest) async throws -> URLRequest {
-        var request = urlRequest
-        if let token = tokenProvider() {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        return request
-    }
-}
-
-struct RefreshTokenAPI: APIDefinition {
-    // ...
-    var requestInterceptors: [RequestInterceptor] {
-        [AuthInterceptor(tokenProvider: { TokenStorage.shared.accessToken })]
-    }
-}
-```
-
-### ResponseInterceptor
-
-응답 받은 후 데이터를 가공한다.
-
-```swift
-struct ErrorResponseInterceptor: ResponseInterceptor {
-    func adapt(_ urlResponse: Response, request: URLRequest) async throws -> Response {
-        // 에러 응답에서 메시지 추출 등
-        if urlResponse.statusCode >= 400 {
-            // 에러 로깅
-        }
-        return urlResponse
-    }
-}
-```
-
----
-
-## 네트워크 모니터링
-
-네트워크 상태 변화를 감지할 수 있다.
-
-```swift
-let monitor = NetworkMonitor.shared
-
-// 현재 상태 확인
-let snapshot = await monitor.currentSnapshot()
-print("연결됨: \(snapshot.status == .satisfied)")
-print("인터페이스: \(snapshot.interfaceTypes)")
-
-// 네트워크 변경 대기
-let newSnapshot = await monitor.waitForChange(from: snapshot, timeout: 30.0)
-```
-
-### NetworkSnapshot
-
-```swift
-struct NetworkSnapshot: Sendable {
-    let status: NetworkReachabilityStatus      // .satisfied, .unsatisfied, .requiresConnection
-    let interfaceTypes: Set<NetworkInterfaceType>  // .wifi, .cellular, .wiredEthernet 등
-}
-```
-
----
-
-## 이벤트 옵저버
-
-네트워크 이벤트를 관찰할 수 있다.
-
-```swift
-struct LoggingObserver: NetworkEventObserving {
-    func handle(_ event: NetworkEvent) {
-        switch event {
-        case .requestStart(let requestID, let method, let url, let retryIndex):
-            print("[\(requestID)] \(method) \(url)")
-        case .responseReceived(let requestID, let statusCode, let byteCount):
-            print("[\(requestID)] 응답: \(statusCode), \(byteCount) bytes")
-        case .requestFinished(let requestID, let statusCode, let byteCount):
-            print("[\(requestID)] 완료: \(statusCode)")
-        case .requestFailed(let requestID, let errorCode, let message):
-            print("[\(requestID)] 실패: \(message)")
-        case .retryScheduled(let requestID, let retryIndex, let delay, let reason):
-            print("[\(requestID)] \(retryIndex + 1)차 재시도 예정 (\(delay)초 후)")
-        default:
-            break
-        }
-    }
-}
-
-let config = NetworkConfiguration(
-    baseURL: URL(string: "https://api.example.com")!,
-    eventObservers: [LoggingObserver()]
-)
-```
-
-### NetworkEvent 종류
-
-| 이벤트 | 시점 |
-|-------|------|
-| `requestStart` | 요청 시작 |
-| `requestAdapted` | 인터셉터 적용 후 |
-| `responseReceived` | 응답 수신 |
-| `requestFinished` | 요청 완료 |
-| `requestFailed` | 요청 실패 |
-| `retryScheduled` | 재시도 예약 |
-
----
-
-## Protobuf 지원
-
-Protocol Buffers도 지원한다.
-
-```swift
-import SwiftProtobuf
-
-struct GetProtobufData: ProtobufAPIDefinition {
-    typealias Parameter = MyRequestProto  // Protobuf 메시지
-    typealias APIResponse = MyResponseProto
-
-    var parameters: MyRequestProto?
-    var method: HTTPMethod { .post }
-    var path: String { "/data" }
-}
-
-let response = try await client.protobufRequest(GetProtobufData(...))
-```
-
----
-
-## 실제 아키텍처 예시
-
-### Repository 레이어와 함께
-
-```swift
-// Domain
 struct User: Decodable, Sendable {
     let id: Int
     let name: String
-    let email: String
 }
 
-protocol UserRepository {
-    func fetchUsers() async throws -> [User]
-    func createUser(name: String, email: String) async throws -> User
-}
+struct GetUser: APIDefinition {
+    typealias Parameter = EmptyParameter
+    typealias APIResponse = User
 
-// Data
-final class UserRepositoryImpl: UserRepository {
-    private let client: DefaultNetworkClient
-
-    init(client: DefaultNetworkClient) {
-        self.client = client
-    }
-
-    func fetchUsers() async throws -> [User] {
-        try await client.request(GetUsers())
-    }
-
-    func createUser(name: String, email: String) async throws -> User {
-        try await client.request(CreateUser(name: name, email: email))
-    }
-}
-
-// App
-@main
-struct MyApp: App {
-    let client: DefaultNetworkClient
-    let userRepository: UserRepository
-
-    init() {
-        do {
-            self.client = try DefaultNetworkClient(configuration: MyAPI())
-        } catch {
-            fatalError("Failed to create DefaultNetworkClient: \(error)")
-        }
-        self.userRepository = UserRepositoryImpl(client: client)
-    }
-
-    var body: some Scene {
-        WindowGroup {
-            UserListView(repository: userRepository)
-        }
-    }
+    var method: HTTPMethod { .get }
+    var path: String { "/users/1" }
 }
 ```
 
-API 정의와 비즈니스 로직이 깔끔하게 분리된다.
-
----
-
-## 다운로드 (InnoNetworkDownload)
-
-대용량 파일 다운로드는 별도 모듈을 사용한다.
+실행은 `DefaultNetworkClient`가 맡습니다.
 
 ```swift
+let client = DefaultNetworkClient(
+    configuration: .safeDefaults(
+        baseURL: URL(string: "https://api.example.com/v1")!
+    )
+)
+
+let user = try await client.request(GetUser())
+print(user.name)
+```
+
+여기서 중요한 건 예전처럼 별도 `APIConfigure` 타입을 기본 설정 entry point로 두지 않는다는 점입니다. `3.0.x`에서는 **configuration object를 명시적으로 생성하는 방식**이 문서와 예제의 중심입니다.
+
+## `safeDefaults`와 `advanced`
+
+지금 문서에서 가장 강조하는 메시지는 간단합니다.
+
+> 특별한 운영 요구가 없다면 `safeDefaults`에 머문다.
+
+### 권장 시작점
+
+```swift
+let client = DefaultNetworkClient(
+    configuration: NetworkConfiguration.safeDefaults(
+        baseURL: URL(string: "https://api.example.com")!
+    )
+)
+```
+
+### 운영 정책이 필요할 때만 `advanced`
+
+```swift
+let configuration = NetworkConfiguration.advanced(
+    baseURL: URL(string: "https://api.example.com")!
+) { builder in
+    builder.timeout = 30
+    builder.retryPolicy = ExponentialBackoffRetryPolicy()
+    builder.trustPolicy = .systemDefault
+}
+
+let client = DefaultNetworkClient(configuration: configuration)
+```
+
+이 구분이 중요한 이유는, `advanced`는 public API이긴 하지만 숫자나 세부 튜닝 값 자체를 contract로 고정하는 surface는 아니기 때문입니다. 프레임워크가 권장하는 경로는 여전히 `safeDefaults`입니다.
+
+## Transport / Operational Surface
+
+`InnoNetwork`를 `3.x` 기준으로 설명할 때는 request/response shape만이 아니라 운영 surface를 같이 봐야 합니다.
+
+### `RetryPolicy`
+
+재시도는 business code에 흩어지는 로직이 아니라 policy로 분리됩니다.
+
+- `RetryPolicy`
+- `ExponentialBackoffRetryPolicy`
+
+### `TrustPolicy`
+
+신뢰 평가도 명시적인 surface로 노출됩니다.
+
+- `.systemDefault`
+- public key pinning
+
+### `EventDeliveryPolicy`
+
+이 부분이 특히 `3.x`다운 변화입니다. 이벤트 전달은 무한 버퍼에 기대지 않고, **bounded buffering과 overflow policy**를 가진 별도 정책으로 다뤄집니다.
+
+즉, 운영 중에 event stream이 과도하게 밀릴 때 어떤 식으로 처리할지를 public surface에서 조절할 수 있습니다.
+
+### `URLQueryEncoder`와 `AnyResponseDecoder`
+
+문서의 톤을 보면 query/form encoding과 decoding도 점점 더 명시적으로 다뤄집니다.
+
+- `URLQueryEncoder`는 deterministic ordering을 가진 query / form 인코딩 경로를 담당합니다.
+- `AnyResponseDecoder`는 explicit decoding strategy를 구성하는 public surface 중 하나입니다.
+
+둘 다 "일상적으로 직접 만지는 타입"은 아닐 수 있지만, `3.x` public contract를 설명할 때는 존재를 짚고 넘어가는 편이 맞습니다.
+
+## Interceptor와 request/response policy
+
+기존 글에서는 `RequestInterceptor`, `ResponseInterceptor`, `RetryPolicy`를 프레임워크의 핵심 전부처럼 설명했습니다. `3.x`에서는 톤을 조금 바꾸는 편이 맞습니다.
+
+이 타입들은 여전히 중요합니다.
+
+- `RequestInterceptor`
+- `ResponseInterceptor`
+- `RetryPolicy`
+
+하지만 프레임워크의 진짜 중심은 "인터셉터를 몇 개 붙일 수 있다"가 아니라, **request execution이 명시적인 정책 경계 안에서 실행된다**는 데 있습니다.
+
+README와 changelog를 보면 request/response execution은 internal transport policy와 explicit decoding strategy 쪽으로 재정리되어 있습니다. 이 레이어는 구현의 핵심이지만, 블로그에서는 **public contract가 아닌 운영 모델 설명** 정도로만 다루는 편이 정확합니다.
+
+## Download Lifecycle
+
+다운로드는 `InnoNetworkDownload` product가 담당합니다.
+
+```swift
+import Foundation
 import InnoNetworkDownload
 
 let manager = DownloadManager.shared
-
-// 다운로드 시작
 let task = await manager.download(
-    url: URL(string: "https://example.com/large-file.zip")!,
-    toDirectory: documentsDirectory
+    url: URL(string: "https://example.com/file.zip")!,
+    toDirectory: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
 )
 
-// 진행률 모니터링 (AsyncSequence)
-for await event in manager.events(for: task) {
-    switch event {
-    case .progress(let progress):
-        print("진행률: \(progress.percentCompleted)%")
-        print("받은 바이트: \(progress.bytesReceived)")
-    case .completed(let url):
-        print("완료: \(url)")
-    case .failed(let error):
-        print("실패: \(error)")
-    case .paused:
-        print("일시정지")
-    case .resumed:
-        print("재개")
-    }
+for await event in await manager.events(for: task) {
+    print(event)
 }
-
-// 일시정지/재개
-await manager.pause(task)
-await manager.resume(task)
 ```
 
-백그라운드 다운로드와 재개 가능한 다운로드를 지원한다.
+이 모듈의 핵심은 단순 파일 다운로드가 아닙니다.
 
----
+- foreground / background orchestration
+- pause / resume / retry
+- listener retention
+- append-log persistence 기반 durability
 
-## InnoNetwork가 해결하는 문제들
+즉, 다운로드를 "URLSession downloadTask 래퍼"가 아니라 **지속성과 이벤트 전달이 있는 lifecycle manager**로 보는 편이 맞습니다.
 
-| 문제 | 해결 방법 |
-|------|----------|
-| URLSession 장황한 코드 | `APIDefinition` 프로토콜로 간결화 |
-| 타입 안전성 부족 | 제네릭으로 요청/응답 강타입 |
-| 에러 처리 불명확 | `NetworkError` 열거형으로 체계화 |
-| 재시도 로직 복잡 | `RetryPolicy` 프로토콜로 추상화 |
-| 콜백 지옥 | async/await 기반 |
-| 인터셉터 구현 번거로움 | `RequestInterceptor`, `ResponseInterceptor` 프로토콜 |
-| 네트워크 상태 추적 어려움 | `NetworkMonitor`, 이벤트 옵저버 |
+필요하면 configuration도 명시적으로 생성할 수 있습니다.
 
----
+```swift
+let configuration = DownloadConfiguration.advanced { builder in
+    builder.maxConnectionsPerHost = 3
+    builder.maxRetryCount = 2
+}
+```
 
-## 요구사항
+새 코드에서는 `safeDefaults()`가 기본, `advanced`가 조정 경로라는 패턴이 여기서도 반복됩니다.
 
-- iOS 26+ / macOS 14+ / tvOS 26+ / watchOS 26+ / visionOS 26+
-- Swift 6.2+
+## WebSocket Lifecycle
 
-Swift 6의 strict concurrency를 지원합니다. `DefaultNetworkClient`는 `actor`로 구현되어 있고, 주요 타입이 `Sendable`을 준수합니다.
+웹소켓은 `InnoNetworkWebSocket`이 맡습니다.
 
----
+```swift
+import Foundation
+import InnoNetworkWebSocket
 
-## 결론
+let task = await WebSocketManager.shared.connect(
+    url: URL(string: "wss://echo.example.com/socket")!
+)
 
-InnoNetwork는 **타입 안전하고 Swift Concurrency 네이티브한 네트워킹 프레임워크**입니다.
+for await event in await WebSocketManager.shared.events(for: task) {
+    print(event)
+}
+```
 
-### 추천하는 경우
+이 product의 핵심은 단순 connect/send/receive API보다 아래 운영 모델입니다.
 
-- API 요청 코드를 깔끔하게 정리하고 싶을 때
-- 타입 안전성을 보장받고 싶을 때
-- 재시도, 인터셉터 등을 구조적으로 처리하고 싶을 때
-- Swift 6 strict concurrency 환경에서 작업할 때
+- reconnect policy
+- handshake-aware close taxonomy
+- reconnect suppression rules
+- heartbeat / pong timeout
+- event delivery policy
 
-### 장점 요약
+그래서 `WebSocketManager`를 설명할 때는 "실시간 통신을 지원한다"보다 **연결 실패와 재연결을 어떤 규칙으로 관리하는지**가 더 중요합니다.
 
-1. **타입 안전** - 제네릭으로 요청/응답 강타입
-2. **간결한 API** - 프로토콜 기반 정의, 기본 구현 제공
-3. **Swift Concurrency** - async/await, actor 완벽 지원
-4. **재시도 정책** - 지수 백오프, 네트워크 변경 감지
-5. **인터셉터** - 요청/응답 가로채기
-6. **이벤트 관찰** - 로깅, 분석, 모니터링
-7. **Swift 6 준비됨** - Sendable, actor 완벽 지원
+## Error Handling
 
----
+`InnoNetwork`는 opaque error보다 명시적인 transport error를 선호합니다.
 
-## 참고 자료
+```swift
+do {
+    let user = try await client.request(GetUser())
+    print(user)
+} catch let error as NetworkError {
+    switch error {
+    case .invalidBaseURL(let url):
+        print("Invalid base URL: \(url)")
+    case .invalidRequestConfiguration(let message):
+        print("Invalid request configuration: \(message)")
+    case .statusCode(let response):
+        print("Unexpected status code: \(response.statusCode)")
+    case .objectMapping(let underlying, _):
+        print("Decoding failed: \(underlying)")
+    case .trustEvaluationFailed(let reason):
+        print("Trust evaluation failed: \(reason)")
+    case .cancelled:
+        print("Request cancelled")
+    default:
+        print(error)
+    }
+}
+```
 
-- [InnoNetwork GitHub 저장소](https://github.com/InnoSquadCorp/InnoNetwork)
-- [Swift Concurrency](https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html)
-- [URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+특히 `invalidRequestConfiguration`은 단순 "뭔가 실패했다"가 아니라, request shape와 policy가 맞지 않는다는 신호에 가깝습니다. 예를 들어 query 인코딩 규칙이나 multipart payload shape가 잘못됐을 때 이런 에러가 나올 수 있습니다.
+
+## Protocol Buffers는 이제 별도 패키지
+
+이전 글에서는 protobuf 지원을 본 패키지의 확장 기능처럼 다뤘지만, `3.0.1` 기준으로는 **`InnoNetworkProtobuf`가 별도 패키지**입니다.
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetworkProtobuf.git", branch: "main")
+]
+```
+
+즉, protobuf가 필요한 앱은 `InnoNetwork`만 추가하면 끝이 아닙니다. 이 분리는 "기능이 사라졌다"기보다, core transport 패키지와 protobuf adapter layer를 더 명확히 분리한 것으로 보는 편이 맞습니다.
+
+## 언제 무엇을 써야 하나
+
+| 상황 | 권장 선택 |
+|------|-----------|
+| 일반적인 REST/HTTP API 요청 | `InnoNetwork` + `NetworkConfiguration.safeDefaults(baseURL:)` |
+| retry / trust / metrics 같은 운영 정책 조정 필요 | `NetworkConfiguration.advanced(baseURL:_:)` |
+| 파일 다운로드, 앱 생명주기와 연결된 progress 추적 | `InnoNetworkDownload` + `DownloadManager` |
+| reconnect와 heartbeat가 중요한 실시간 연결 | `InnoNetworkWebSocket` + `WebSocketManager` |
+| protobuf request/response 모델 필요 | `InnoNetwork` + `InnoNetworkProtobuf` |
+
+## 마무리
+
+`InnoNetwork 3.0.1`을 한 문장으로 정리하면, "타입 안전 HTTP 클라이언트"보다는 **운영 정책이 명시된 네트워크 프레임워크 제품군**이 더 정확한 설명입니다.
+
+`APIDefinition`과 `DefaultNetworkClient`는 여전히 출발점입니다. 하지만 실제로 `3.x`를 잘 쓰려면 다음 네 가지를 같이 이해해야 합니다.
+
+- `safeDefaults`가 기본 경로라는 점
+- `advanced`는 운영 정책이 필요할 때만 쓴다는 점
+- download / websocket lifecycle이 별도 product라는 점
+- protobuf가 별도 패키지로 분리되었다는 점
+
+더 자세히 보려면 아래 문서부터 읽는 걸 추천합니다.
+
+1. [README](https://github.com/InnoSquadCorp/InnoNetwork)
+2. [`API_STABILITY.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/API_STABILITY.md)
+3. [`Examples/README.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/Examples/README.md)
+4. [`docs/releases/3.0.1.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/docs/releases/3.0.1.md)


### PR DESCRIPTION
## Summary
- refresh InnoDI Korean/English posts for the 3.0.1 validation contract
- refresh InnoNetwork Korean/English posts for the 3.0.1 product split and operational surface
- rely on commit-based `last_modified_at` so the updated date is reflected automatically

## Validation
- bundle exec jekyll build