### PR TITLE
docs: refresh Inno blog posts around best practices and sample synergy

### DIFF
--- a/_posts/2026-02-23-innodi-swift-macro-di-en.md
+++ b/_posts/2026-02-23-innodi-swift-macro-di-en.md
@@ -1,355 +1,235 @@
 ---
-title: "InnoDI: A Type-Safe Dependency Injection Library Built with Swift Macros"
+title: "InnoDI Best Practices: Using Swift Macro DI to Preserve App Structure"
 date: 2026-02-23 00:00:00 +0900
-lang: en
 translation_key: innodi-swift-macro-di
+lang: en
+description: "Why InnoDI is useful, how to place Swift macro-based dependency injection at composition roots and feature boundaries, and how InnoSample applies those best practices."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, dependency-injection, macro, di, clean-architecture]
+tags: [swift, iOS, dependency-injection, macro, di, clean-architecture, swiftui, tuist]
 author: ethan
 toc: true
 comments: true
 ---
 
-## Introduction
+## Why dependency injection gets hard in real apps
 
-When I first introduced `InnoDI`, the framing was mostly "a Swift Macro library that removes DI boilerplate." That description is still directionally true, but it no longer captures the real public surface of `3.0.1`.
+Dependency injection starts simple in an iOS app. You pass an `APIClient`, a `Repository`, or a `UseCase` through an initializer. The trouble starts when the app grows.
 
-Today, the core story is **static dependency graph and scope validation**.
+- Temporary factories appear around screens.
+- Global singletons become harder to remove.
+- Preview and test wiring drift away from the real app graph.
+- Features start constructing implementation details from other features.
+- Code review no longer shows who owns each dependency or how long it lives.
 
-In other words, `InnoDI` is not a runtime service locator. It is a framework for declaring DI wiring explicitly and rejecting invalid graphs as early as possible at compile time and build time.
+[`InnoDI`](https://github.com/InnoSquadCorp/InnoDI) does not hide this problem behind a runtime container. It asks you to declare the dependency graph with Swift macros, then catches structural drift through compile-time and build-time validation.
 
-This post revisits `InnoDI` from that perspective.
+The appeal is straightforward: **wiring remains visible, graph ownership is reviewable, and failures move earlier than runtime.**
 
-## Why revisit it now
+## The boundary InnoDI should own
 
-The `3.0.x` line is not mainly about new macro syntax. The bigger shift is that the framework makes its validation boundaries much more explicit:
+InnoDI is not most valuable as a global place to pull dependencies from. It is most valuable at construction boundaries.
 
-- strict name-based resolution
-- declaration-order enforcement
-- `concrete: true` opt-in
-- `asyncFactory` scope restrictions
-- custom `init` rejection for `@DIContainer` types
-- build-stage DAG validation and plugin-based enforcement
+InnoDI should own:
 
-So if we describe `InnoDI` only as "a macro that generates init code," we miss the part that matters most in a larger codebase: **which wiring patterns are allowed, and which are rejected**.
+- app composition roots
+- layer and feature container wiring
+- shared/input scopes
+- parent-child container ownership
+- graph validation and DAG inspection
+- SwiftUI root-boundary wiring
 
-## What InnoDI owns and what it does not
+InnoDI should not own:
 
-The README describes `InnoDI` as a **static dependency graph and scope validation** framework.
+- screen state transitions
+- navigation stacks
+- network retry or session lifecycle
+- business rules
+- per-action runtime overrides
 
-What `InnoDI` owns:
+In other words, InnoDI owns construction-time structure. Runtime state belongs in [`InnoFlow`]({% post_url 2026-02-23-innoflow-unidirectional-architecture-en %}), navigation belongs in [`InnoRouter`]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %}), and network execution policy belongs in [`InnoNetwork`]({% post_url 2026-02-23-innonetwork-type-safe-networking-en %}).
 
-- dependency wiring declared with `@DIContainer` and `@Provide`
-- lifecycle modeling through `DIScope`
-- compile-time and build-time validation
-- DAG rendering and validation artifacts
-
-What `InnoDI` does not own:
-
-- runtime state transitions
-- navigation policy
-- network session or transport lifecycle
-- container resolution as a runtime state machine
-
-Within the InnoSquad stack, state transitions belong in `InnoFlow`, navigation belongs in `InnoRouter`, and transport/session lifecycle belongs in `InnoNetwork`. `InnoDI` stays focused on **static wiring** across those layers.
-
-## Core API
-
-## Install
-
-For `InnoDI 3.0.1`, the package setup starts here.
+## Installation and the smallest useful shape
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.1")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "4.3.0")
 ]
 ```
 
-Then add the product to your target.
+Add `InnoDISwiftUI` when a target needs the SwiftUI root helpers.
 
 ```swift
 .target(
     name: "YourApp",
-    dependencies: ["InnoDI"]
+    dependencies: [
+        "InnoDI",
+        "InnoDISwiftUI"
+    ],
+    plugins: [
+        .plugin(name: "InnoDIDAGValidationPlugin", package: "InnoDI")
+    ]
 )
 ```
 
-### `@DIContainer`
-
-Declare a struct as a DI container.
+A minimal container looks like this:
 
 ```swift
-@DIContainer(validate: true, root: false, validateDAG: true, mainActor: false)
-struct AppContainer {}
-```
-
-Two things matter here:
-
-- the macro generates container initializers and accessors
-- the same declaration is also validation input
-
-There is an important constraint as well: a type annotated with `@DIContainer` cannot define its own custom `init`. That rule is enforced in the type body, same-file extensions, and cross-file extensions during build validation.
-
-### `@Provide`
-
-Declare a dependency.
-
-```swift
-@Provide(
-    _ scope: DIScope = .shared,
-    _ type: Type.self? = nil,
-    with: [KeyPath] = [],
-    factory: Any? = nil,
-    asyncFactory: Any? = nil,
-    concrete: Bool = false
-)
-```
-
-There are three main styles:
-
-- receive external values with `.input`
-- describe construction with `factory` or `asyncFactory`
-- use `Type.self` + `with:` for AutoWiring
-
-### `DIScope`
-
-In `InnoDI`, scope is not just a convenience feature. It is directly tied to validation rules.
-
-| Scope | Meaning | Notes |
-|------|------|------|
-| `.input` | must be injected when the container is created | no factory allowed |
-| `.shared` | created once and cached for the container lifetime | order rules apply |
-| `.transient` | creates a fresh instance on each access | not cached |
-
-## A minimal example
-
-This is the shape most users start with.
-
-```swift
+import Foundation
 import InnoDI
 
-protocol APIClientProtocol {
-    func fetch() async throws -> Data
+struct APIClient {
+    let baseURL: URL
 }
 
-struct APIClient: APIClientProtocol {
-    let baseURL: String
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: URL
 
-    func fetch() async throws -> Data {
-        Data()
+    @Provide(.shared, factory: { (baseURL: URL) in
+        APIClient(baseURL: baseURL)
+    }, concrete: true)
+    var apiClient: APIClient
+}
+```
+
+The important point is that `@Provide` is a declaration, not a dynamic registration. The container surface says what enters the graph and what the graph provides.
+
+## Best practice 1. Start at the composition root
+
+The top-level app container should connect infrastructure and major composition boundaries, not every detail in the app. [`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)'s `AppContainer` is the clearest example.
+
+```swift
+@MainActor
+@DIContainer(root: true, mainActor: true)
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: URL
+
+    @Provide(.shared, factory: { (baseURL: URL) in
+        LayerContainer(baseURL: baseURL)
+    }, concrete: true)
+    var layerContainer: LayerContainer
+
+    @Provide(.shared, factory: { (layerContainer: LayerContainer) in
+        layerContainer.featureUseCases
+    })
+    var featureUseCases: any FeatureUseCaseContaining
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \FeatureContainer.useCases, parent: \AppContainer.featureUseCases)],
+        featureRoot: FeatureRootScene.self
+    )
+    var featureContainer: FeatureContainer
+}
+```
+
+`AppContainer` does not need to know the internals of `RemoteContainer`, `DataContainer`, `DomainContainer`, or each leaf feature. It connects the next composition boundary and stops there.
+
+That is the first rule: **a parent container should not build the whole app; it should connect the next owned boundary.**
+
+## Best practice 2. Prefer small boundary containers over one giant graph
+
+One huge app-wide DI graph often becomes a service locator with a nicer name. InnoDI works better when each architectural boundary gets a small container.
+
+InnoSample's `LayerContainer` connects `Remote -> Data -> Domain` and exposes only the use case surface needed by features.
+
+```swift
+@DIContainer
+public struct LayerContainer {
+    @Provide(.input)
+    public var baseURL: URL
+
+    @Provide(.shared, factory: { (baseURL: URL) in
+        RemoteContainer(baseURL: baseURL)
+    }, concrete: true)
+    var remoteContainer: RemoteContainer
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \DomainContainer.dataContainer, parent: \LayerContainer.repositories)]
+    )
+    var domainContainer: DomainContainer
+
+    public var featureUseCases: any FeatureUseCaseContaining {
+        domainContainer
     }
 }
-
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var baseURL: String
-
-    @Provide(.shared, APIClient.self, with: [\.baseURL])
-    var apiClient: any APIClientProtocol
-}
-
-let container = AppContainer(baseURL: "https://api.example.com")
-let client = container.apiClient
 ```
 
-The most important part is not the generated code. It is the **strict matching rule**: the key paths listed in `with:` must match the initializer parameter names of the concrete type exactly.
+The benefits are practical:
 
-## AutoWiring and strict matching
+- `App` does not know remote/data/domain wiring details.
+- `Features` do not know repository implementations.
+- `Domain` does not know remote models or network clients.
+- Each graph stays small enough to review.
 
-One of the defining characteristics of `InnoDI 3.x` is that **name-based resolution is intentionally strict**.
+DI becomes a way to preserve dependency direction, not just a way to construct objects.
+
+## Best practice 3. Use `@SubContainer` for feature ownership
+
+InnoDI 4.x is especially useful when parent-child container ownership should be explicit.
 
 ```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var config: AppConfig
-
-    @Provide(.input)
-    var logger: Logger
-
-    @Provide(.shared, APIClient.self, with: [\.config, \.logger])
-    var apiClient: any APIClientProtocol
-}
-```
-
-Conceptually, this expects something like `APIClient(config:logger:)`. If the names do not match, the macro does not try to guess.
-
-That can feel rigid, but it also means the declaration and the generated wiring follow the exact same rule. Humans and tools read the graph the same way.
-
-When names do not line up, a factory closure is the better choice.
-
-```swift
-@Provide(.shared, factory: { (config: AppConfig) in
-    APIClient(configuration: config, timeout: 30)
-})
-var apiClient: any APIClientProtocol
-```
-
-## Declaration order and scope rules
-
-According to `PolicyBoundaries.md`, declaration order is part of the validation contract.
-
-- `.input` members are always available
-- sync `.shared` members can reference inputs and **earlier** sync shared members
-- async `.shared` members can reference inputs, all sync shared members, and **earlier** async shared members
-- `.transient` members may reference any container member, but matching is still strict
-
-That means member order is not just style. It defines **dependency availability**.
-
-## `concrete: true` and protocol-first design
-
-`InnoDI` is protocol-first by default. Exposing a concrete shared or transient dependency requires explicit opt-in.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var apiClient: any APIClientProtocol
-
-    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
-        HomeViewModel(apiClient: apiClient)
-    }, concrete: true)
-    var homeViewModel: HomeViewModel
-}
-```
-
-This is a small but useful rule. It makes concrete exposure deliberate instead of accidental and nudges the codebase toward dependency inversion.
-
-## Async factories and their limits
-
-Use `asyncFactory` when construction is asynchronous.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var config: AppConfig
-
-    @Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
-        try await DatabaseClient.connect(config: config)
-    })
-    var databaseClient: any DatabaseClientProtocol
-}
-```
-
-Again, the framework is explicit about what it allows:
-
-- `factory` and `asyncFactory` cannot be used together
-- `.input` cannot use `asyncFactory`
-- `asyncFactory` must actually be an `async` closure
-
-This is a good example of the broader `3.x` direction: not just "we support it," but "we define the boundary precisely."
-
-## Validation layers
-
-This is where `InnoDI` becomes much more than a macro convenience layer.
-
-### 1. Local container validation
-
-At macro expansion time, `InnoDI` validates:
-
-- unknown scopes
-- missing factories
-- invalid `.input` factory configuration
-- strict name-based resolution
-- declaration-order violations
-- missing `concrete: true`
-- local cycles and unknown dependencies
-- async factory validity
-- same-file `init` conflicts
-
-### 2. Build-stage validation
-
-Build validation scans package sources more broadly and extends the rule set to **cross-file extension `init` conflicts**.
-
-So macro success is not the whole story. The build phase tightens the contract further.
-
-### 3. Global DAG validation
-
-Graph-wide cycles and ambiguity are validated through the CLI or the build plugin.
-
-```bash
-swift run InnoDI-DependencyGraph --root . --validate-dag
-```
-
-You can also opt a container out of DAG validation:
-
-```swift
-@DIContainer(validateDAG: false)
-struct PreviewContainer {
-    @Provide(.input)
-    var mockAPIClient: any APIClientProtocol
-}
-```
-
-That is best used for preview or test containers that you do not want included in the global graph contract.
-
-## `PolicyBoundaries` and custom `init` restrictions
-
-To understand `3.0.x`, the README is not enough. `PolicyBoundaries.md` matters because it explains the framework's determinism choices.
-
-Key points:
-
-- cross-file extension targets try semantic resolution first
-- ambiguous or unsupported cases are not guessed
-- generic argument extensions and constrained `where` extensions are excluded from the build-stage custom `init` rule
-- nested paths such as `Outer.Container` are supported
-
-This is a deliberate tradeoff. `InnoDI` prefers **deterministic validation** over speculative matching.
-
-## Testing and override strategy
-
-The main testing story is not a separate runtime override registry. It is the generated initializer with override parameters.
-
-```swift
-let container = AppContainer(
-    baseURL: "https://test.example.com",
-    apiClient: MockAPIClient()
+@SubContainer(
+    scope: .shared,
+    bindings: [
+        (child: \EntireTabContainer.peopleCoordinator, parent: \FeatureContainer.peopleCoordinator),
+        (child: \EntireTabContainer.postsCoordinator, parent: \FeatureContainer.postsCoordinator),
+        (child: \EntireTabContainer.settingsCoordinator, parent: \FeatureContainer.settingsCoordinator),
+    ]
 )
+var entireTabContainer: EntireTabContainer
 ```
 
-That has two practical benefits:
+The parent passes only the inputs a child needs. The child container owns its coordinator and view-root composition.
 
-- the difference between production and test wiring is visible directly in the initializer
-- mock replacement works without a runtime registry or container mutation step
+For SwiftUI apps, `featureRoot:` can connect the generated root scene as well. This removes repetitive startup wiring while keeping ownership visible.
 
-## CLI, plugin, and artifacts
+## Best practice 4. Treat scopes as architecture language
 
-In a team setting, the most important part is often not the macro diagnostic itself but the **plugin and artifacts**.
+DI scope is not just a performance setting. It says something about ownership and lifetime.
 
-Attach `InnoDIDAGValidationPlugin` to a target if you want DAG problems to fail the build. During validation, the framework produces artifacts such as:
+- `.input`: values supplied from outside the container, such as `baseURL`, environment, or feature input.
+- `.shared`: infrastructure or identity-bearing objects owned by the boundary, such as network clients, repositories, or coordinators.
+- computed properties: lightweight stateless values, such as use cases that can be rebuilt from shared repositories.
 
-- `result.json`
-- `validation-metrics.json`
-- `validation-summary.md`
-- `dag-validation-stamp.txt`
-- `dag-validation-metrics.json`
-- `dag-validation-summary.md`
+InnoSample keeps repositories shared and exposes concrete stateless use cases from `DomainContainer`. That removes unnecessary abstraction while keeping features away from repository implementations.
 
-In CI, those summaries and metrics are usually more useful than raw stderr alone.
+## What you gain by adopting it
 
-## When to use which option
+Used this way, InnoDI gives you:
 
-| Situation | Recommended choice |
-|------|------|
-| external values at app startup | `.input` |
-| services reused for one container lifetime | `.shared` |
-| ViewModels or adapters that need fresh instances | `.transient` with `concrete: true` when needed |
-| initializer parameter names match member names | `Type.self` + `with:` |
-| names differ or custom mapping is needed | `factory` |
-| async construction is required | `asyncFactory` |
-| preview or test-only containers should stay out of global DAG checks | `validateDAG: false` |
+- visible construction ownership
+- fewer feature-to-feature implementation leaks
+- reviewable dependency graphs
+- macro and build validation for wiring mistakes
+- clearer SwiftUI root and preview/test entry points
+- a consistent place to attach new features
 
-## Closing thoughts
+The team benefit is large. When wiring is implicit, new features tend to construct whatever is closest. InnoDI makes the intended boundary harder to ignore.
 
-If I had to summarize `InnoDI 3.0.1` in one sentence, I would no longer call it just "macro-based DI." A better description is **a DI wiring framework with explicit static graph rules**.
+## When not to use it
 
-Reducing boilerplate is still useful. But in a larger codebase, the real value is that wiring failures show up during the build instead of surfacing later as runtime surprises.
+Macro DI is not necessary for every app.
 
-If you want to go deeper, this reading order works best:
+- Small prototypes with only a few endpoints
+- Apps where runtime plugin registration is the main requirement
+- Legacy apps that intentionally keep global singletons
+- Experiments where speed matters more than graph validation
 
-1. [README](https://github.com/InnoSquadCorp/InnoDI)
-2. [`Validation.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/Validation.md)
-3. [`PolicyBoundaries.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md)
-4. [`ModuleWideInitDetection.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md)
+In those cases, simple factories or runtime dependency tools may be a better fit.
+
+InnoDI becomes attractive when the app has multiple features, layers, and platform targets. The more expensive it is to preserve construction boundaries, the more valuable InnoDI becomes.
+
+## How InnoSample uses it
+
+[`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice-en %}) does not scatter InnoDI throughout the app.
+
+- `AppContainer` owns app-root composition.
+- `LayerContainer` owns `Remote/Data/Domain` composition.
+- `FeatureContainer` owns leaf-feature coordinator composition.
+- Feature logic receives dependencies and does not need to know the DI framework.
+
+That is the strongest way to use InnoDI: **treat DI as architecture notation, not convenience access.** Then InnoDI becomes a tool for keeping app structure intact over time.

--- a/_posts/2026-02-23-innodi-swift-macro-di.md
+++ b/_posts/2026-02-23-innodi-swift-macro-di.md
@@ -1,349 +1,235 @@
 ---
-title: "InnoDI: Swift Macro 기반 타입 안전 의존성 주입 라이브러리"
+title: "InnoDI Best Practice: Swift Macro DI를 앱 구조로 고정하는 법"
 date: 2026-02-23 00:00:00 +0900
-lang: ko-KR
 translation_key: innodi-swift-macro-di
+lang: ko-KR
+description: "InnoDI를 왜 써야 하는지, Swift macro 기반 DI를 composition root와 feature boundary에 어떻게 배치해야 하는지, InnoSample의 실제 구조로 설명합니다."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, dependency-injection, macro, di, clean-architecture]
+tags: [swift, iOS, dependency-injection, macro, di, clean-architecture, swiftui, tuist]
 author: ethan
 toc: true
 comments: true
 ---
 
-## 들어가며
+## 왜 DI가 실무에서 어려운가
 
-`InnoDI`를 처음 소개했을 때는 "Swift Macro로 DI 보일러플레이트를 줄여주는 라이브러리"라는 설명이 중심이었습니다. 그 설명도 여전히 틀리지는 않지만, `3.0.1` 기준의 실제 공개 surface를 보면 지금의 핵심은 **정적 dependency graph와 scope validation**입니다.
+iOS 앱에서 의존성 주입은 처음에는 단순합니다. `APIClient`, `Repository`, `UseCase`를 생성자에 넣으면 됩니다. 문제는 앱이 커졌을 때 시작됩니다.
 
-즉, `InnoDI`는 런타임 service locator가 아니라 **DI wiring을 명시적으로 선언하고, 잘못된 그래프를 컴파일/빌드 단계에서 최대한 빨리 막는 프레임워크**에 가깝습니다.
+- 화면마다 임시 factory가 생깁니다.
+- 전역 singleton이 늘어납니다.
+- preview/test override가 실제 앱 graph와 달라집니다.
+- feature가 다른 feature의 구현을 직접 알기 시작합니다.
+- "이 객체는 누가 만들고 얼마나 오래 살아야 하는가"가 코드 리뷰에서 보이지 않습니다.
 
-이 글은 그 기준으로 `InnoDI`를 다시 정리합니다.
+[`InnoDI`](https://github.com/InnoSquadCorp/InnoDI)는 이 문제를 런타임 container로 숨기지 않습니다. 대신 Swift macro로 DI graph를 선언하게 만들고, compile-time/build-time validation으로 구조 drift를 더 빨리 발견하게 합니다.
 
-## 왜 다시 봐야 하나
+핵심 매력은 명확합니다. **의존성 wiring이 코드로 보이고, graph가 검증 가능하며, 생성 책임이 앱 구조 안에 남습니다.**
 
-`3.0.x`에서 `InnoDI`의 중심은 새 매크로 문법이 아닙니다. 오히려 아래 같은 검증 경계가 더 또렷해졌습니다.
+## InnoDI가 소유하는 경계
 
-- strict name-based resolution
-- declaration-order enforcement
-- `concrete: true` opt-in
-- `asyncFactory`의 scope 제약
-- `@DIContainer`가 선언된 타입의 custom `init` 금지
-- build-stage DAG validation과 plugin 기반 검증
+InnoDI가 잘하는 일은 객체를 "어디서든 꺼내 쓰게" 만드는 것이 아닙니다. 좋은 사용 방식은 반대입니다. InnoDI는 생성 경계에서만 강하게 쓰고, feature 내부 로직에는 최대한 드러내지 않는 편이 좋습니다.
 
-그래서 지금 `InnoDI`를 설명할 때는 "매크로가 init을 생성해 준다"에서 멈추면 부족합니다. **어떤 wiring이 허용되고, 어떤 wiring이 거부되는지**까지 함께 설명해야 실제 코드베이스와 맞습니다.
+InnoDI가 소유해야 하는 것:
 
-## InnoDI가 소유하는 것과 소유하지 않는 것
+- 앱의 composition root
+- layer container와 feature container wiring
+- shared/input scope
+- parent-child container ownership
+- graph validation과 DAG inspection
+- SwiftUI root boundary 연결
 
-README의 표현을 그대로 빌리면, `InnoDI`는 **static dependency graph and scope validation** 프레임워크입니다.
+InnoDI가 소유하지 말아야 하는 것:
 
-`InnoDI`가 소유하는 것:
+- 화면 상태 전이
+- navigation stack
+- network retry/session lifecycle
+- 비즈니스 규칙
+- per-action runtime dependency override
 
-- `@DIContainer`와 `@Provide`로 선언한 의존성 wiring
-- `DIScope` 기반 수명주기 표현
-- compile-time / build-time validation
-- DAG 시각화와 validation artifact
+즉 InnoDI는 앱의 "생성 시점 구조"를 다룹니다. 런타임 상태는 [`InnoFlow`]({% post_url 2026-02-23-innoflow-unidirectional-architecture %}), 화면 이동은 [`InnoRouter`]({% post_url 2026-02-23-innorouter-swiftui-navigation %}), 네트워크 실행 정책은 [`InnoNetwork`]({% post_url 2026-02-23-innonetwork-type-safe-networking %}) 같은 더 맞는 경계에 맡기는 편이 좋습니다.
 
-`InnoDI`가 소유하지 않는 것:
-
-- 런타임 상태 전이
-- 화면 이동이나 navigation policy
-- 네트워크 세션/transport lifecycle
-- 컨테이너 해석을 이용한 runtime state machine
-
-InnoSquad 스택 기준으로 보면 상태 전이는 `InnoFlow`, navigation은 `InnoRouter`, transport/session lifecycle은 `InnoNetwork` 쪽 책임입니다. `InnoDI`는 이 레이어들을 연결하는 **정적 wiring**에 집중합니다.
-
-## 핵심 API
-
-## 설치
-
-`InnoDI 3.0.1` 기준 설치는 아래처럼 시작하면 됩니다.
+## 설치와 기본 사용
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "3.0.1")
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", from: "4.3.0")
 ]
 ```
 
-타겟에는 보통 이렇게 연결합니다.
+SwiftUI root helper가 필요하면 `InnoDISwiftUI`도 함께 추가합니다.
 
 ```swift
 .target(
     name: "YourApp",
-    dependencies: ["InnoDI"]
+    dependencies: [
+        "InnoDI",
+        "InnoDISwiftUI"
+    ],
+    plugins: [
+        .plugin(name: "InnoDIDAGValidationPlugin", package: "InnoDI")
+    ]
 )
 ```
 
-### `@DIContainer`
-
-컨테이너 struct를 선언합니다.
+가장 작은 형태는 아래처럼 읽으면 됩니다.
 
 ```swift
-@DIContainer(validate: true, root: false, validateDAG: true, mainActor: false)
-struct AppContainer {}
-```
-
-핵심 포인트는 두 가지입니다.
-
-- 매크로가 컨테이너 initializer와 accessor를 생성합니다.
-- 동시에 잘못된 wiring을 컴파일 단계에서 거부합니다.
-
-또 하나 중요한 제약이 있습니다. `@DIContainer`가 붙은 타입에는 user-defined `init`을 둘 수 없습니다. 타입 본문은 물론, same-file extension과 cross-file extension까지 build validation이 확인합니다.
-
-### `@Provide`
-
-의존성을 선언합니다.
-
-```swift
-@Provide(
-    _ scope: DIScope = .shared,
-    _ type: Type.self? = nil,
-    with: [KeyPath] = [],
-    factory: Any? = nil,
-    asyncFactory: Any? = nil,
-    concrete: Bool = false
-)
-```
-
-선언 방식은 크게 세 가지입니다.
-
-- `.input`으로 외부 입력을 받기
-- `factory` / `asyncFactory`로 생성 규칙을 명시하기
-- `Type.self` + `with:` 조합으로 AutoWiring 쓰기
-
-### `DIScope`
-
-`InnoDI`의 scope는 단순한 convenience가 아니라, validation 규칙과 직접 연결됩니다.
-
-| Scope | 의미 | 비고 |
-|------|------|------|
-| `.input` | 컨테이너 생성 시 외부에서 반드시 주입 | factory 불가 |
-| `.shared` | 컨테이너 수명 동안 1회 생성 후 재사용 | sync/async declaration order 규칙 적용 |
-| `.transient` | 접근할 때마다 새 인스턴스 생성 | 캐시되지 않음 |
-
-## 시작 예제
-
-가장 기본적인 모습은 아래와 같습니다.
-
-```swift
+import Foundation
 import InnoDI
 
-protocol APIClientProtocol {
-    func fetch() async throws -> Data
+struct APIClient {
+    let baseURL: URL
 }
 
-struct APIClient: APIClientProtocol {
-    let baseURL: String
+@DIContainer
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: URL
 
-    func fetch() async throws -> Data {
-        Data()
+    @Provide(.shared, factory: { (baseURL: URL) in
+        APIClient(baseURL: baseURL)
+    }, concrete: true)
+    var apiClient: APIClient
+}
+```
+
+여기서 중요한 것은 `@Provide`가 "등록"이 아니라 "선언"이라는 점입니다. 컨테이너가 어떤 입력을 받고 어떤 shared dependency를 제공하는지 타입으로 드러납니다.
+
+## Best practice 1. Composition root에서 시작합니다
+
+앱의 최상위 컨테이너는 인프라와 큰 composition boundary만 연결해야 합니다. [`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)의 `AppContainer`는 좋은 예입니다.
+
+```swift
+@MainActor
+@DIContainer(root: true, mainActor: true)
+struct AppContainer {
+    @Provide(.input)
+    var baseURL: URL
+
+    @Provide(.shared, factory: { (baseURL: URL) in
+        LayerContainer(baseURL: baseURL)
+    }, concrete: true)
+    var layerContainer: LayerContainer
+
+    @Provide(.shared, factory: { (layerContainer: LayerContainer) in
+        layerContainer.featureUseCases
+    })
+    var featureUseCases: any FeatureUseCaseContaining
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \FeatureContainer.useCases, parent: \AppContainer.featureUseCases)],
+        featureRoot: FeatureRootScene.self
+    )
+    var featureContainer: FeatureContainer
+}
+```
+
+이 구조에서 `AppContainer`는 `RemoteContainer`, `DataContainer`, `DomainContainer`의 세부 구현을 직접 알지 않습니다. `LayerContainer`와 `FeatureContainer`라는 큰 경계만 연결합니다.
+
+이것이 InnoDI의 첫 번째 best practice입니다. **상위 컨테이너는 모든 것을 만들지 말고, 다음 composition boundary만 알게 하십시오.**
+
+## Best practice 2. 큰 graph 하나보다 작은 container 여러 개가 낫습니다
+
+DI container 하나에 앱 전체 객체를 몰아넣으면 결국 이름만 다른 service locator가 됩니다. InnoDI는 계층마다 작은 container를 두었을 때 더 강합니다.
+
+InnoSample의 `LayerContainer`는 `Remote -> Data -> Domain`을 연결하고, 밖으로는 feature가 필요한 use case surface만 제공합니다.
+
+```swift
+@DIContainer
+public struct LayerContainer {
+    @Provide(.input)
+    public var baseURL: URL
+
+    @Provide(.shared, factory: { (baseURL: URL) in
+        RemoteContainer(baseURL: baseURL)
+    }, concrete: true)
+    var remoteContainer: RemoteContainer
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \DomainContainer.dataContainer, parent: \LayerContainer.repositories)]
+    )
+    var domainContainer: DomainContainer
+
+    public var featureUseCases: any FeatureUseCaseContaining {
+        domainContainer
     }
 }
-
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var baseURL: String
-
-    @Provide(.shared, APIClient.self, with: [\.baseURL])
-    var apiClient: any APIClientProtocol
-}
-
-let container = AppContainer(baseURL: "https://api.example.com")
-let client = container.apiClient
 ```
 
-여기서 중요한 건 "자동 생성"보다 **엄격한 matching rule**입니다. `with:`에 넘긴 key path 이름은 concrete type의 init parameter 이름과 정확히 맞아야 합니다.
+이 방식의 장점은 분명합니다.
 
-## AutoWiring과 strict matching
+- `App`은 remote/data/domain 내부 조립을 모릅니다.
+- `Features`는 repository 구현을 모릅니다.
+- `Domain`은 remote model과 network client를 모릅니다.
+- graph는 계층별로 작게 검증됩니다.
 
-`InnoDI 3.x`의 핵심 변화 중 하나는 **name-based resolution을 더 엄격하게 다루는 것**입니다.
+DI는 객체를 많이 만드는 도구가 아니라 **의존 방향을 보존하는 도구**가 됩니다.
+
+## Best practice 3. `@SubContainer`로 feature root를 연결합니다
+
+InnoDI 4.x에서 특히 매력적인 부분은 parent-child container 관계를 코드로 선언할 수 있다는 점입니다.
 
 ```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var config: AppConfig
-
-    @Provide(.input)
-    var logger: Logger
-
-    @Provide(.shared, APIClient.self, with: [\.config, \.logger])
-    var apiClient: any APIClientProtocol
-}
-```
-
-위 선언은 개념적으로 `APIClient(config:logger:)` 같은 init을 기대합니다. 이름이 다르면 자동으로 맞춰주지 않습니다. 이 제약은 번거롭지만, 선언을 읽는 사람과 매크로가 **같은 wiring 규칙**을 보게 만든다는 장점이 있습니다.
-
-AutoWiring이 맞지 않는 경우는 factory closure를 쓰는 편이 낫습니다.
-
-```swift
-@Provide(.shared, factory: { (config: AppConfig) in
-    APIClient(configuration: config, timeout: 30)
-})
-var apiClient: any APIClientProtocol
-```
-
-## Declaration Order와 scope 규칙
-
-`PolicyBoundaries.md` 기준으로 `InnoDI`는 선언 순서를 validation contract에 포함합니다.
-
-- `.input`은 항상 참조 가능합니다.
-- sync `.shared`는 input과 **앞서 선언된** sync shared만 참조할 수 있습니다.
-- async `.shared`는 input, 모든 sync shared, 그리고 **앞서 선언된** async shared를 참조할 수 있습니다.
-- `.transient`는 어떤 멤버든 참조할 수 있지만 이름 matching은 여전히 엄격합니다.
-
-즉, 컨테이너 멤버 순서가 단순 스타일이 아니라 **의존성 가용성 규칙**이 됩니다.
-
-## `concrete: true`와 protocol-first 설계
-
-`InnoDI`는 protocol-first 설계를 기본값으로 둡니다. 그래서 concrete shared/transient dependency를 직접 노출할 때는 opt-in이 필요합니다.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var apiClient: any APIClientProtocol
-
-    @Provide(.transient, factory: { (apiClient: any APIClientProtocol) in
-        HomeViewModel(apiClient: apiClient)
-    }, concrete: true)
-    var homeViewModel: HomeViewModel
-}
-```
-
-이 규칙 덕분에 concrete 타입 노출이 "실수로" 늘어나는 것을 막고, 의존성 역전 원칙을 의식적으로 지키게 됩니다.
-
-## 비동기 팩토리와 제약
-
-비동기 초기화가 필요하면 `asyncFactory`를 사용할 수 있습니다.
-
-```swift
-@DIContainer
-struct AppContainer {
-    @Provide(.input)
-    var config: AppConfig
-
-    @Provide(.shared, asyncFactory: { (config: AppConfig) async throws in
-        try await DatabaseClient.connect(config: config)
-    })
-    var databaseClient: any DatabaseClientProtocol
-}
-```
-
-여기에도 명확한 제약이 있습니다.
-
-- `factory`와 `asyncFactory`는 동시에 사용할 수 없습니다.
-- `.input`에는 `asyncFactory`를 둘 수 없습니다.
-- `asyncFactory`는 실제 `async` closure여야 합니다.
-
-결국 `InnoDI`는 "지원한다"보다 "어디까지 허용한다"를 명확히 문서화한 프레임워크에 가깝습니다.
-
-## Validation Layers
-
-`InnoDI`의 진짜 가치가 드러나는 부분은 validation입니다.
-
-### 1. Local Container Validation
-
-매크로 단계에서 아래를 검사합니다.
-
-- unknown scope
-- missing factory
-- `.input`의 잘못된 factory 구성
-- strict name-based resolution
-- declaration-order 위반
-- `concrete: true` 누락
-- local cycle / unknown dependency
-- async factory validity
-- same-file `init` 충돌
-
-### 2. Build-Stage Validation
-
-빌드 단계에서는 same-package 소스를 더 넓게 스캔해서 **cross-file extension `init` 충돌**까지 확인합니다.
-
-즉, 매크로만 통과했다고 끝이 아니라 빌드 레벨에서 한 번 더 보강합니다.
-
-### 3. Global DAG Validation
-
-그래프 전체 차원의 순환과 ambiguity는 CLI나 build plugin으로 검증합니다.
-
-```bash
-swift run InnoDI-DependencyGraph --root . --validate-dag
-```
-
-필요하면 특정 컨테이너는 DAG 검증에서 제외할 수 있습니다.
-
-```swift
-@DIContainer(validateDAG: false)
-struct PreviewContainer {
-    @Provide(.input)
-    var mockAPIClient: any APIClientProtocol
-}
-```
-
-이 옵션은 "validation을 끄는 편의 기능"이라기보다, preview/test 전용 컨테이너처럼 **그래프 전역 검증에 참여시키고 싶지 않은 타입**을 분리하는 데 더 적합합니다.
-
-## `PolicyBoundaries`와 custom `init` restriction
-
-`3.0.x`를 이해하려면 README만으로는 부족하고, `PolicyBoundaries.md`를 같이 봐야 합니다. 핵심은 다음입니다.
-
-- cross-file extension target은 semantic resolution을 먼저 시도합니다.
-- ambiguous / unsupported case는 추측하지 않고 conservative fallback 또는 exclusion으로 처리합니다.
-- generic argument extension, constrained `where` extension은 build-stage custom `init` 규칙에서 제외됩니다.
-- nested path(`Outer.Container`) matching을 지원합니다.
-
-이 선택은 "최대한 많이 맞추겠다"보다 **deterministic validation**을 우선하는 방향입니다.
-
-## 테스트와 override 전략
-
-`InnoDI`의 테스트 경험은 별도 override container를 만드는 방식보다, **생성된 initializer override parameter**를 활용하는 쪽이 중심입니다.
-
-```swift
-let container = AppContainer(
-    baseURL: "https://test.example.com",
-    apiClient: MockAPIClient()
+@SubContainer(
+    scope: .shared,
+    bindings: [
+        (child: \EntireTabContainer.peopleCoordinator, parent: \FeatureContainer.peopleCoordinator),
+        (child: \EntireTabContainer.postsCoordinator, parent: \FeatureContainer.postsCoordinator),
+        (child: \EntireTabContainer.settingsCoordinator, parent: \FeatureContainer.settingsCoordinator),
+    ]
 )
+var entireTabContainer: EntireTabContainer
 ```
 
-이 방식의 장점은 두 가지입니다.
+feature root를 이렇게 연결하면 상위는 child가 필요한 입력만 넘기고, child container는 자기 소유의 coordinator나 view root를 조립합니다.
 
-- 프로덕션 wiring과 테스트 wiring의 차이가 init parameter에서 바로 드러납니다.
-- 별도의 runtime registry 없이 mock 교체가 가능합니다.
+SwiftUI 앱에서는 `featureRoot:`를 통해 root scene까지 연결할 수 있습니다. 그러면 앱 시작점에서 "container를 만들고 root view에 넘기는 반복 코드"가 줄어듭니다.
 
-## CLI, Plugin, Artifact
+## Best practice 4. `.input`과 `.shared`를 아키텍처 언어로 씁니다
 
-실무에서 `InnoDI`를 팀 단위로 쓰게 되면 매크로 진단보다 **artifact와 plugin**이 중요해집니다.
+DI scope는 단순 성능 옵션이 아닙니다. scope는 객체의 수명과 ownership을 표현합니다.
 
-`InnoDIDAGValidationPlugin`을 target에 붙이면 DAG 문제를 빌드 실패로 올릴 수 있습니다. 또한 validation 과정에서 아래 artifact가 생성됩니다.
+- `.input`: 외부에서 주입되는 값입니다. `baseURL`, environment, feature input처럼 container가 직접 만들면 안 되는 값에 씁니다.
+- `.shared`: container boundary 안에서 공유되는 인프라입니다. network client, repository, coordinator처럼 identity나 수명이 중요한 객체에 씁니다.
+- computed property: stateless use case처럼 매번 만들어도 의미가 같은 값에 씁니다.
 
-- `result.json`
-- `validation-metrics.json`
-- `validation-summary.md`
-- `dag-validation-stamp.txt`
-- `dag-validation-metrics.json`
-- `dag-validation-summary.md`
+InnoSample은 repository는 shared로 두고, use case는 `DomainContainer`에서 concrete computed value로 제공합니다. 이 선택은 추상화를 줄이면서도 feature가 repository를 직접 알지 않게 합니다.
 
-CI에서는 raw stderr만 보는 대신 Markdown summary와 metrics artifact를 우선 읽는 편이 훨씬 낫습니다.
+## 도입했을 때 얻는 장점
 
-## 언제 어떤 옵션을 써야 하나
+InnoDI를 제대로 쓰면 다음 이점이 생깁니다.
 
-| 상황 | 권장 선택 |
-|------|-----------|
-| 앱 시작 시 외부 값 주입 | `.input` |
-| 컨테이너 단위로 재사용할 서비스 | `.shared` |
-| 접근할 때마다 새 인스턴스가 필요한 ViewModel/Adapter | `.transient` + 필요 시 `concrete: true` |
-| init parameter 이름이 프로퍼티 이름과 정확히 맞음 | `Type.self` + `with:` |
-| 이름이 다르거나 변환 로직이 필요함 | `factory` |
-| 비동기 생성 필요 | `asyncFactory` |
-| preview/test 전용 컨테이너를 전역 DAG에서 분리 | `validateDAG: false` |
+- 생성 책임이 앱 구조 안에 남습니다.
+- feature가 다른 feature의 구현을 직접 만들지 않습니다.
+- DI graph가 코드 리뷰에서 보입니다.
+- macro/build validation으로 wiring mistake를 빨리 잡습니다.
+- SwiftUI root와 test/previews의 entry point가 정리됩니다.
+- 새 feature를 추가할 때 "어느 container에 붙여야 하는가"가 명확해집니다.
 
-## 마무리
+특히 팀 단위 개발에서는 마지막 장점이 큽니다. DI가 암묵적이면 새 feature가 가장 가까운 파일에서 아무 객체나 만들기 쉽습니다. InnoDI는 그 유혹을 줄이고, 앱의 생성 경계를 계속 같은 모양으로 유지하게 만듭니다.
 
-`InnoDI 3.0.1`을 한 문장으로 요약하면, "Swift Macro 기반 DI"보다 **정적 그래프 규칙이 명확한 DI wiring framework**가 더 정확한 설명입니다.
+## 언제 쓰지 않는 편이 나은가
 
-보일러플레이트를 줄여주는 건 여전히 장점입니다. 하지만 실제로 팀에서 가치를 만드는 지점은, wiring이 커질수록 **문제가 나중이 아니라 빌드 시점에 드러난다**는 데 있습니다.
+모든 앱에 macro DI가 필요한 것은 아닙니다.
 
-문서를 더 보고 싶다면 아래 순서가 가장 좋습니다.
+- endpoint 두세 개짜리 작은 prototype
+- 런타임 plugin registration이 핵심인 앱
+- global singleton을 의도적으로 유지하는 legacy 앱
+- DI graph 검증보다 빠른 실험이 더 중요한 단계
 
-1. [README](https://github.com/InnoSquadCorp/InnoDI)
-2. [`Validation.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/Validation.md)
-3. [`PolicyBoundaries.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/PolicyBoundaries.md)
-4. [`ModuleWideInitDetection.md`](https://github.com/InnoSquadCorp/InnoDI/blob/main/Sources/InnoDI/InnoDI.docc/ModuleWideInitDetection.md)
+이런 경우에는 가벼운 factory나 runtime dependency tool이 더 나을 수 있습니다.
+
+반대로 앱이 여러 feature, layer, platform target으로 나뉘기 시작했다면 InnoDI는 좋은 선택입니다. 객체 생성 자체보다 **생성 경계를 유지하는 비용**이 커지는 시점부터 가치가 커집니다.
+
+## InnoSample에서의 결론
+
+[`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice %})은 InnoDI를 앱 전역에 흩뿌리지 않습니다.
+
+- `AppContainer`는 앱 root composition만 소유합니다.
+- `LayerContainer`는 `Remote/Data/Domain` 조립만 소유합니다.
+- `FeatureContainer`는 leaf feature coordinator 조립만 소유합니다.
+- feature logic은 생성된 dependency를 사용할 뿐, DI framework를 직접 알 필요가 없습니다.
+
+이것이 InnoDI를 가장 설득력 있게 쓰는 방식입니다. **DI를 편의 기능이 아니라 아키텍처 경계의 표기법으로 쓰는 것.** 그때 InnoDI는 단순한 객체 생성 도구가 아니라, 앱 구조를 오래 유지하는 장치가 됩니다.

--- a/_posts/2026-02-23-innoflow-unidirectional-architecture-en.md
+++ b/_posts/2026-02-23-innoflow-unidirectional-architecture-en.md
@@ -1,594 +1,256 @@
 ---
-title: "InnoFlow: A one-way architecture framework for SwiftUI"
+title: "InnoFlow Best Practices: Managing SwiftUI Feature Logic with One-Way State"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innoflow-unidirectional-architecture
 lang: en
+description: "Why InnoFlow is useful, how to keep SwiftUI feature logic behind reducer/state/action/effect boundaries, and how InnoSample applies that pattern."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, state-management, unidirectional, elm-architecture, tca, swiftui]
+tags: [swift, iOS, state-management, unidirectional, reducer, swiftui, architecture, testing]
 author: ethan
 toc: true
 comments: true
 ---
 
-## Why revisit it now?
+## Why feature state gets hard in real SwiftUI apps
 
-The original InnoFlow post was directionally right, but it was still centered on the `v2` mental model.
+SwiftUI is excellent for building small screens quickly. As an app grows, feature logic often leaks into views.
 
-- reducers were shown as handwritten `reduce(into:action:)`
-- examples used `Store.binding(\.field, ...)`
-- installation still pointed to `2.0.0`
-- phase-driven modeling looked like an extra feature instead of a core `v3` story
+- Each `onAppear` gets its own loading rules.
+- Error, retry, refresh, and empty states scatter across the view tree.
+- Async cancellation policy varies by screen.
+- Navigation intent mixes with business state.
+- Tests become view-heavy while logic coverage stays thin.
 
-The actual codebase has moved. In `3.0.0`, the framework is much more explicit about what it is:
+[`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow) addresses this by organizing feature logic around reducers, state, actions, and effects. It is not trying to replace SwiftUI. It is trying to keep business and domain transitions out of the view layer.
 
-> InnoFlow is not a generic app state machine. It is a reducer-first framework for business and domain state transitions.
+## The boundary InnoFlow should own
 
-The official authoring surface is now `var body: some Reducer<State, Action>`. Composition is centered on `Reduce`, `CombineReducers`, `Scope`, `IfLet`, `IfCaseLet`, and `ForEachReducer`. Phase-heavy features use `PhaseMap` as the runtime phase ownership layer.
+InnoFlow should own business and domain state transitions inside a feature.
 
-So this update is not about polishing wording. It is about describing the framework that exists today.
+It should own:
 
----
+- feature state
+- user and system actions
+- async effects
+- loading/error/loaded phases
+- feature-local one-shot intent before navigation consumes it
+- reducer composition
 
-## What InnoFlow owns, and what it does not
-
-According to the current `ARCHITECTURE_CONTRACT.md`, InnoFlow owns these areas.
-
-| Area | Core types | Responsibility |
-|---|---|---|
-| Reducer authoring | `@InnoFlow`, `Reducer`, `Reduce`, `CombineReducers` | define state transitions through reducer composition |
-| Child composition | `Scope`, `IfLet`, `IfCaseLet`, `ForEachReducer` | compose child features explicitly |
-| SwiftUI runtime | `Store`, `ScopedStore`, `SelectedStore`, `@BindableField` | observe state and derive projections in SwiftUI |
-| Effect runtime | `EffectTask`, `EffectContext`, FIFO queue | async work, timing, cancellation |
-| Phase-driven modeling | `PhaseMap`, `PhaseTransitionGraph`, `ActionMatcher` | phase contracts for phase-heavy features |
-| Testing / observability | `TestStore`, `InnoFlowTesting`, `StoreInstrumentation` | deterministic testing and runtime instrumentation |
-
-And it intentionally does not own:
+It should not own:
 
 - concrete navigation stacks
-- transport, reconnect, and session lifecycle
-- construction-time dependency graphs
-- window, scene, and immersive-space runtime concerns
+- URLSession or transport retry
+- dependency graph construction
+- SwiftUI layout
+- app lifecycle, scenes, or windows
 
-That boundary matters. If a framework owns all of those concerns at once, reducers turn into giant orchestration hubs. InnoFlow 3.0 explicitly avoids that.
+The boundary matters. If InnoFlow becomes a giant application framework that also owns networking and navigation, its value gets blurry. Keep it small: feature `Logic` targets own state transitions, and everything else stays outside.
 
----
+## Installation and official authoring surface
 
-## The official authoring surface
+```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoFlow.git", from: "4.0.0")
+]
+```
 
-The biggest practical shift in `3.0` is this: the framework no longer presents handwritten `reduce(into:action:)` as the primary way to author features.
+Use the products by role.
 
-### `@InnoFlow` + `var body: some Reducer`
+```swift
+.target(
+    name: "YourFeatureLogic",
+    dependencies: ["InnoFlow"]
+)
+
+.target(
+    name: "YourFeatureUI",
+    dependencies: ["InnoFlowSwiftUI"]
+)
+
+.testTarget(
+    name: "YourFeatureTests",
+    dependencies: ["InnoFlowTesting"]
+)
+```
+
+InnoFlow 4.x's recommended authoring surface is `@InnoFlow` plus `var body: some Reducer<State, Action>`.
 
 ```swift
 import InnoFlow
 
 @InnoFlow
 struct CounterFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    var count = 0
-    @BindableField var step = 1
-  }
-
-  enum Action: Equatable, Sendable {
-    case increment
-    case decrement
-    case setStep(Int)
-  }
-
-  var body: some Reducer<State, Action> {
-    Reduce { state, action in
-      switch action {
-      case .increment:
-        state.count += state.step
-        return .none
-
-      case .decrement:
-        state.count -= state.step
-        return .none
-
-      case .setStep(let step):
-        state.step = max(1, step)
-        return .none
-      }
-    }
-  }
-}
-```
-
-This is the official `3.0` feature shape.
-
-- a feature defines `State`, `Action`, and `body`
-- `@InnoFlow` generates the reducer entry point from that composition
-- the handwritten part is now domain logic and composition, not boilerplate
-
-### `Reduce` is the primitive
-
-`Reduce` is the closure-backed primitive reducer that the rest of the surface builds on.
-
-```swift
-Reduce<State, Action> { state, action in
-  // mutate state
-  // return EffectTask<Action>
-}
-```
-
-The unidirectional model itself has not changed. State still mutates in the reducer, and effects still come back as `EffectTask<Action>`. What changed is the official authoring entry point.
-
----
-
-## Composition surface
-
-InnoFlow 3.0 intentionally keeps the composition surface small instead of growing multiple authoring styles.
-
-### `CombineReducers`
-
-Use `CombineReducers` to run parent logic and helper reducers in declaration order.
-
-```swift
-var body: some Reducer<State, Action> {
-  CombineReducers {
-    Reduce { state, action in
-      switch action {
-      case .load:
-        state.isLoading = true
-        return .send(.child(.start))
-      case .child(.finished):
-        state.isLoading = false
-        return .none
-      default:
-        return .none
-      }
+    struct State: Equatable, Sendable, DefaultInitializable {
+        var count = 0
     }
 
-    AnalyticsReducer()
-  }
-}
-```
+    enum Action: Equatable, Sendable {
+        case increment
+        case decrement
+    }
 
-### `Scope`
-
-Use `Scope` when child state is always present and should be lifted into the parent action space.
-
-```swift
-@InnoFlow
-struct ParentFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    var child = ChildFeature.State()
-    var isLoading = false
-  }
-
-  enum Action: Equatable, Sendable {
-    case load
-    case child(ChildFeature.Action)
-  }
-
-  var body: some Reducer<State, Action> {
-    CombineReducers {
-      Reduce { state, action in
-        switch action {
-        case .load:
-          state.isLoading = true
-          return .send(.child(.start))
-        case .child(.finished):
-          state.isLoading = false
-          return .none
-        default:
-          return .none
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .increment:
+                state.count += 1
+                return .none
+            case .decrement:
+                state.count -= 1
+                return .none
+            }
         }
-      }
-
-      Scope(
-        state: \.child,
-        action: .childCasePath,
-        reducer: ChildFeature()
-      )
     }
-  }
 }
 ```
 
-With `@InnoFlow`, cases like `case child(ChildFeature.Action)` synthesize `childCasePath` automatically.
+## Best practice 1. Keep it inside `Logic` targets
 
-### `IfLet`, `IfCaseLet`, `ForEachReducer`
+InnoSample splits leaf features into `Interface / Logic / UI / Router / Testing / Tests`. InnoFlow belongs in `Logic`.
 
-These complete the official child-composition set:
+That placement gives you clean boundaries:
 
-- `IfLet` for optional child state
-- `IfCaseLet` for enum-backed child state
-- `ForEachReducer` for collection-backed child state
+- reducers do not know SwiftUI layout
+- reducers do not know InnoRouter route stacks
+- reducers do not construct network clients
+- UI renders state and sends actions
+- Router consumes navigation intent
 
-That is a meaningful part of the `3.0` story. Child reducer composition is no longer a pattern each team has to reinvent.
+InnoFlow owns how a feature thinks. SwiftUI owns how that state is displayed.
 
----
+## Best practice 2. Pass dependencies into reducers
 
-## SwiftUI runtime
-
-### `Store` is a SwiftUI-first runtime
-
-The basic usage is still simple.
+InnoSample's `PeopleFeatureReducer` receives use cases through a small dependency bundle.
 
 ```swift
-import InnoFlow
-import SwiftUI
-
-struct CounterView: View {
-  @State private var store: Store<CounterFeature>
-
-  init(store: Store<CounterFeature> = Store(reducer: CounterFeature())) {
-    _store = State(initialValue: store)
-  }
-
-  var body: some View {
-    VStack(spacing: 20) {
-      Text("Count: \(store.count)")
-        .font(.largeTitle)
-
-      HStack(spacing: 24) {
-        Button("−") { store.send(.decrement) }
-        Button("+") { store.send(.increment) }
-      }
-
-      Stepper(
-        "Step: \(store.step)",
-        value: store.binding(\.$step, send: CounterFeature.Action.setStep)
-      )
-    }
-  }
-}
-```
-
-The binding syntax is one of the concrete `v3` updates:
-
-- older style: `store.binding(\.step, ...)`
-- current style: `store.binding(\.$step, ...)`
-
-Bindings are intentionally explicit opt-in. Only `@BindableField` properties participate in SwiftUI binding.
-
-### `ScopedStore`
-
-Mutable child flows use `ScopedStore`.
-
-```swift
-let child = store.scope(state: \.child, action: .childCasePath)
-```
-
-That is different from a read-only projection. It creates a mutable child boundary that participates in the store runtime.
-
-### `SelectedStore`
-
-For expensive read-only derived values, `SelectedStore` is now the official path.
-
-```swift
-let summary = store.select(dependingOn: (\.profile, \.permissions)) { profile, permissions in
-  DashboardBadge(
-    title: profile.name,
-    isReady: profile.isReady && permissions.isReady
-  )
-}
-```
-
-This is not just a convenience memoization trick. It is the documented way to let large SwiftUI views observe only an `Equatable` projection.
-
-The rule of thumb is:
-
-- mutable child flow -> `ScopedStore`
-- read-only derived value -> `SelectedStore`
-- one to three explicit dependency slices -> `select(dependingOn:)`
-- otherwise -> `select { ... }` as the always-refresh fallback
-
-### Preview
-
-The canonical preview entry point is `Store.preview(...)`.
-
-```swift
-#Preview("Counter") {
-  CounterView(
-    store: .preview(
-      reducer: CounterFeature(),
-      initialState: .init(count: 3, step: 2)
-    )
-  )
-}
-```
-
-That keeps preview-only setup explicit without changing production store wiring.
-
----
-
-## Effect runtime
-
-`EffectTask<Action>` remains the only effect DSL:
-
-- `.none`
-- `.send(action)`
-- `.run { send, context in ... }`
-- `.merge(...)`
-- `.concatenate(...)`
-- `.cancel(id)`
-- `.cancellable(id:cancelInFlight:)`
-- `.debounce(id:for:)`
-- `.throttle(id:for:leading:trailing:)`
-- `.animation(_:)`
-
-But the important `3.0` story is the runtime contract around it.
-
-### `EffectContext`
-
-New code should prefer `.run { send, context in ... }`.
-
-```swift
-return .run { send, context in
-  do {
-    try await context.sleep(for: .milliseconds(300))
-    try await context.checkCancellation()
-    await send(.finished)
-  } catch is CancellationError {
-    return
-  }
-}
-```
-
-That matters because:
-
-- `StoreClock` controls both scheduling operators and explicit delays
-- tests stay deterministic
-- cancellation checks stop spreading as ad hoc code
-
-### FIFO queue semantics
-
-`Store` dispatches reducer input and effect follow-up actions through a single FIFO queue.
-
-| Behavior | Meaning |
-|---|---|
-| `.send` | immediate follow-up, but queued rather than reducer-reentrant |
-| `.run` | re-enters the same queue after its suspension boundary |
-| `.concatenate` | preserves declaration order |
-| `.merge` | observes child completion order |
-
-In other words, effect ordering is documented runtime behavior, not incidental implementation detail.
-
-### `StoreInstrumentation`
-
-`3.0` also gives observability a clearer public surface.
-
-```swift
-let instrumentation: StoreInstrumentation<Feature.Action> = .combined(
-  .osLog(logger: logger),
-  .sink { event in
-    switch event {
-    case .runStarted:
-      metrics.increment("feature.effect.run_started")
-    case .runFinished:
-      metrics.increment("feature.effect.run_finished")
-    case .actionEmitted:
-      metrics.increment("feature.effect.emitted")
-    case .actionDropped:
-      metrics.increment("feature.effect.dropped")
-    case .effectsCancelled:
-      metrics.increment("feature.effect.cancelled")
-    }
-  }
-)
-```
-
-The design intent is clear: backend-specific metrics or traces should plug into `sink`, `osLog`, or `combined`, not alter reducer semantics.
-
----
-
-## Phase-driven modeling
-
-This is the most visible new chapter in InnoFlow 3.0, but it is easy to misunderstand.
-
-> `PhaseMap` is the runtime phase ownership layer. `PhaseTransitionGraph` is the topology validation tool.
-
-That does not turn InnoFlow into a generic FSM runtime.
-
-### `PhaseMap`
-
-```swift
-@InnoFlow
-struct ItemsFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    enum Phase: Hashable, Sendable {
-      case idle
-      case loading
-      case loaded
-      case failed
+@InnoFlow(phaseManaged: true)
+struct PeopleFeatureReducer {
+    struct Dependencies: Sendable {
+        let loadPeople: @Sendable () async throws -> [UserSummary]
     }
 
-    var phase: Phase = .idle
-    var items: [Item] = []
-    var errorMessage: String?
-  }
+    struct State: Equatable, Sendable, DefaultInitializable {
+        enum Phase: Hashable, Sendable {
+            case idle
+            case loading
+            case loaded
+            case failed
+        }
 
-  enum Action: Equatable, Sendable {
-    case load
-    case _loaded([Item])
-    case _failed(String)
-  }
-
-  static var phaseMap: PhaseMap<State, Action, State.Phase> {
-    PhaseMap(\.phase) {
-      From(.idle) {
-        On(.load, to: .loading)
-      }
-      From(.loading) {
-        On(Action.loadedCasePath, to: .loaded)
-        On(Action.failedCasePath, to: .failed)
-      }
-      From(.loaded) {
-        On(.load, to: .loading)
-      }
-      From(.failed) {
-        On(.load, to: .loading)
-      }
+        var phase: Phase = .idle
+        var isLoading = false
+        var people: [UserSummary] = []
+        var errorMessage: String?
+        var pendingSettingsRequest: PeopleSettingsRequest?
     }
-  }
 
-  static var phaseGraph: PhaseTransitionGraph<State.Phase> {
-    phaseMap.derivedGraph
-  }
-
-  var body: some Reducer<State, Action> {
-    let phaseMap: PhaseMap<State, Action, State.Phase> = Self.phaseMap
-
-    return Reduce { state, action in
-      switch action {
-      case .load:
-        return .none
-      case ._loaded(let items):
-        state.items = items
-        return .none
-      case ._failed(let message):
-        state.errorMessage = message
-        return .none
-      }
-    }
-    .phaseMap(phaseMap)
-  }
+    let dependencies: Dependencies
 }
 ```
 
-The important rules are:
+The reducer does not know repositories, network clients, or DI containers. It only knows a feature-level operation: `loadPeople`.
 
-- `PhaseMap` runs after the base reducer
-- once active, `PhaseMap` owns the declared phase key path
-- unmatched phase/action pairs remain legal no-ops by default
-- stronger coverage is opt-in in tests, not a forced runtime rule
+That choice pays off in tests. Reducer tests can swap the closure for success, failure, and delayed paths without building remote infrastructure.
 
-### When to use it
+## Best practice 3. Model phases explicitly
 
-- when a feature already has a meaningful phase enum
-- when legal transitions are part of the business contract
-- when imperative `state.phase = ...` writes are spreading across reducer branches
-
-### When not to use it
-
-- route stacks
-- session lifecycle
-- reconnect or transport retries
-- dependency graph wiring
-- generic effect bookkeeping
-
-### `PhaseTransitionGraph`
-
-`PhaseTransitionGraph` is for static topology validation.
+As screens grow, combinations of `isLoading`, `errorMessage`, and `hasLoaded` become hard to reason about. InnoFlow 4.x lets you express intended state transitions with `phaseManaged` and `PhaseMap`.
 
 ```swift
-let report = ItemsFeature.phaseGraph.validationReport(
-  allPhases: [.idle, .loading, .loaded, .failed],
-  root: .idle,
-  terminalPhases: [.loaded]
-)
-
-precondition(report.issues.isEmpty)
-```
-
-When phase movement depends on payload-bearing actions, the current docs prefer case-path based `On(...)` rules and `ActionMatcher`-style matching over ad hoc graph metadata.
-
-The graph is deliberately kept focused on validation. Guard-bearing transition metadata and runtime conditional resolution stay out of it on purpose.
-
-`validatePhaseTransitions(...)` still exists, but it is now a backward-compatibility surface, not the recommended one for new examples.
-
----
-
-## Testing
-
-`TestStore` remains central, but `3.0` makes phase-aware testing a much more explicit part of the story.
-
-```swift
-import InnoFlowTesting
-
-@Test
-@MainActor
-func loadFlow() async {
-  let store = TestStore(reducer: ItemsFeature())
-
-  let phaseMap: PhaseMap<ItemsFeature.State, ItemsFeature.Action, ItemsFeature.State.Phase> =
-    ItemsFeature.phaseMap
-
-  await store.send(.load, through: phaseMap) {
-    $0.phase = .loading
-  }
-
-  await store.receive(._loaded(items), through: phaseMap) {
-    $0.phase = .loaded
-    $0.items = items
-  }
+static var phaseMap: PhaseMap<State, Action, State.Phase> {
+    PhaseMap(\State.phase) {
+        From(.idle) {
+            On(.onAppear, to: .loading)
+            On(.refresh, to: .loading)
+        }
+        From(.loading) {
+            On(Action.peopleLoadedCasePath, to: .loaded)
+            On(Action.peopleFailedCasePath, to: .failed)
+        }
+        From(.loaded) {
+            On(.refresh, to: .loading)
+        }
+    }
 }
 ```
 
-The important part is `through: phaseMap`. A phase-heavy feature can now test reducer behavior and documented phase ownership through the same public surface.
+Phase is not a visual detail. It is the feature's progress model. Spinners, retry buttons, and empty states can then derive from that model.
 
-A few other testing points are worth calling out:
+## Best practice 4. Keep async effects and cancellation together
 
-- project child tests from a parent `TestStore` with `scope(state:action:)`
-- inject `StoreClock.manual(...)` for debounce/throttle and delay control
-- diff-oriented mismatch diagnostics make reducer failures easier to read
-
-Testing moved closer to "verify the documented contract" and further away from "poke the runtime and hope it behaves."
-
----
-
-## Which surface should you use?
-
-| Situation | Recommended surface |
-|---|---|
-| simple feature logic | `@InnoFlow` + `Reduce` |
-| parent/child composition | `CombineReducers` + `Scope` |
-| optional child | `IfLet` |
-| enum-backed child | `IfCaseLet` |
-| collection-backed child | `ForEachReducer` |
-| mutable child flow | `ScopedStore` |
-| read-only expensive projection | `SelectedStore` |
-| phase-heavy feature | `PhaseMap` + `phaseMap.derivedGraph` |
-| runtime observability | `StoreInstrumentation` |
-| previews and review passes | `Store.preview(...)` |
-
-That table captures the design intent well. InnoFlow is not a "one giant store" framework. It is a framework that keeps reducer composition, state ownership, and runtime behavior explicit.
-
----
-
-## Installation and requirements
+Async loading is not just creating a `Task`. Refresh and repeated appearance events need a policy.
 
 ```swift
-dependencies: [
-  .package(url: "https://github.com/InnoSquadCorp/InnoFlow.git", from: "3.0.0")
-]
+private func loadPeople() -> EffectTask<Action> {
+    let loadPeople = dependencies.loadPeople
+
+    return .run { send, _ in
+        do {
+            let people = try await loadPeople()
+            await send(.peopleLoaded(people))
+        } catch {
+            await send(.peopleFailed(error.localizedDescription))
+        }
+    }
+    .cancellable("people-feature-load", cancelInFlight: true)
+}
 ```
 
-Current package requirements:
+The effect and cancellation policy live together. That is easier to review and test than scattered `Task` blocks in views.
 
-- iOS 18+
-- macOS 15+
-- tvOS 18+
-- watchOS 11+
-- visionOS 2+
-- Swift tools 6.2
+## Best practice 5. Create navigation intent, not navigation stacks
 
-If tests need `TestStore`, `ManualTestClock`, and phase-aware helpers, add `InnoFlowTesting` to the test target as well.
+If a reducer directly mutates route stacks, feature logic becomes tied to the navigation framework. InnoSample instead leaves one-shot intent in state.
 
----
+```swift
+case .openSettings(let request):
+    state.pendingSettingsRequest = PeopleSettingsRequest(request: request)
+    return .none
+```
 
-## Closing thoughts
+Then the feature coordinator consumes that intent and the root `EntireTabCoordinator` mediates the actual sibling-feature movement.
 
-The shortest accurate description of InnoFlow today is this:
+This keeps responsibilities separate:
 
-> InnoFlow is less a "SwiftUI state management library" and more a reducer-first framework that organizes business and domain transitions around explicit runtime contracts.
+- reducer says "I want to open settings"
+- coordinator turns that intent into a route command
+- sibling imports remain at the parent boundary
 
-That is why `3.0` feels different.
+That is where InnoFlow and [`InnoRouter`]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %}) complement each other.
 
-1. feature authoring is now clearly centered on reducer body composition
-2. child composition is standardized around the `Scope` family
-3. SwiftUI runtime surfaces like `SelectedStore`, `Store.preview`, and `StoreInstrumentation` are much sharper
-4. `PhaseMap` and `PhaseTransitionGraph` make phase-heavy features easier to document and validate
-5. navigation, session lifecycle, and dependency graph ownership remain outside the framework boundary
+## What you gain by adopting it
 
-If your state logic is getting more complex but you do not want every app concern shoved into one giant state machine, InnoFlow 3.0 offers a more disciplined balance.
+Used well, InnoFlow gives feature logic these properties:
 
-## References
+- state transitions are readable in one place
+- async loading and error paths are explicit actions
+- reducers can be tested without UI
+- navigation intent can stay separate from route execution
+- features do not know network, DI, or router implementations
+- larger features can be decomposed with `Reduce`, `Scope`, `IfLet`, and `ForEachReducer`
 
-- [InnoFlow GitHub Repository](https://github.com/InnoSquadCorp/InnoFlow)
-- [Architecture Contract](https://github.com/InnoSquadCorp/InnoFlow/blob/main/ARCHITECTURE_CONTRACT.md)
-- [Phase-Driven Modeling](https://github.com/InnoSquadCorp/InnoFlow/blob/main/PHASE_DRIVEN_MODELING.md)
-- [Canonical Sample App](https://github.com/InnoSquadCorp/InnoFlow/tree/main/Examples/InnoFlowSampleApp)
+SwiftUI handles rendering well, but it does not automatically define ownership for business state. InnoFlow fills that missing boundary.
+
+## When it is a good fit
+
+InnoFlow is a good fit for:
+
+- apps with repeated loading/error/retry flows
+- teams that want logic tests without booting views
+- SwiftUI features that are accumulating business logic
+- teams that like reducer-based design but do not want a broad application framework
+- apps that keep navigation and networking in separate boundaries
+
+It may be too much for a very small screen or a one-off form. If the state transition fits in a few lines, `@State` and `Observable` may be enough.
+
+## How InnoSample uses it
+
+In [`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice-en %}), InnoFlow owns feature logic.
+
+- `PeopleFeatureLogic` manages loading people and emitting settings intent.
+- `PostsFeatureLogic` manages loading posts and highlights modal intent.
+- `SettingsFeatureLogic` manages loading todos and emitting people intent.
+- Routers consume intent and perform navigation.
+- `App` and `Layers` do not know reducer internals.
+
+That is the best way to use InnoFlow: **state transitions in reducers, navigation in routers, dependency construction in DI containers.** The result is SwiftUI feature code that is easier to test, easier to reason about, and easier to keep stable over time.

--- a/_posts/2026-02-23-innoflow-unidirectional-architecture.md
+++ b/_posts/2026-02-23-innoflow-unidirectional-architecture.md
@@ -1,594 +1,256 @@
 ---
-title: "InnoFlow: SwiftUI를 위한 단방향 아키텍처 프레임워크"
+title: "InnoFlow Best Practice: SwiftUI Feature Logic을 단방향으로 관리하기"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innoflow-unidirectional-architecture
 lang: ko-KR
+description: "InnoFlow를 왜 써야 하는지, SwiftUI feature logic을 reducer/state/action/effect 경계로 어떻게 나누는 것이 좋은지 InnoSample 기준으로 설명합니다."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, state-management, unidirectional, elm-architecture, tca, swiftui]
+tags: [swift, iOS, state-management, unidirectional, reducer, swiftui, architecture, testing]
 author: ethan
 toc: true
 comments: true
 ---
 
-## 왜 다시 봐야 할까요?
+## 왜 feature state가 실무에서 어려운가
 
-기존 `InnoFlow` 소개 글은 분명 맞는 설명이었습니다. 다만 중심이 `v2` 시절 문법에 머물러 있었습니다.
+SwiftUI는 작은 화면을 빠르게 만들기 좋습니다. 하지만 앱이 커질수록 feature logic은 view 안으로 쉽게 새어 들어갑니다.
 
-- reducer를 `reduce(into:action:)`로 직접 작성하는 방식
-- `Store.binding(\.field, ...)` 중심의 예제
-- `2.0.0` 패키지 버전
-- phase-driven modeling을 부가 기능처럼 다루는 설명
+- `onAppear`마다 loading 조건이 달라집니다.
+- error, retry, refresh, empty state가 view에 흩어집니다.
+- async task 취소 정책이 화면마다 다릅니다.
+- navigation intent와 business state가 섞입니다.
+- 테스트는 view snapshot 중심으로만 남고 logic test가 약해집니다.
 
-실제 `InnoFlow` 코드베이스는 `3.0.0`에서 방향이 더 명확해졌습니다.
+[`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow)는 이 문제를 reducer/state/action/effect 구조로 정리합니다. 핵심은 "SwiftUI를 대체하는 것"이 아닙니다. **SwiftUI view에서 business/domain state transition을 분리하는 것**입니다.
 
-> InnoFlow는 generic app state machine이 아니라, 비즈니스와 도메인 상태 전환을 위한 reducer-first framework입니다.
+## InnoFlow가 소유하는 경계
 
-공식 authoring surface는 이제 `var body: some Reducer<State, Action>`입니다. composition은 `Reduce`, `CombineReducers`, `Scope`, `IfLet`, `IfCaseLet`, `ForEachReducer` 중심으로 정리됐고, phase-heavy feature는 `PhaseMap`이 runtime phase ownership을 맡습니다.
+InnoFlow는 feature의 비즈니스 상태 전이를 소유합니다.
 
-즉, 이번 업데이트의 핵심은 "단방향 상태관리 프레임워크"라는 추상적인 소개를 넘어서, 현재 InnoFlow가 실제로 무엇을 소유하고 어떤 방식으로 쓰이도록 설계되었는지 다시 설명하는 데 있습니다.
+소유해야 하는 것:
 
----
+- feature state
+- user/action event
+- async effect
+- loading/error/loaded phase
+- one-shot intent를 만들기 전까지의 feature-local 상태
+- reducer composition
 
-## InnoFlow가 소유하는 것과 소유하지 않는 것
-
-현재 `ARCHITECTURE_CONTRACT.md` 기준으로 InnoFlow는 아래 영역을 소유합니다.
-
-| 영역 | 핵심 타입 | 설명 |
-|---|---|---|
-| Reducer authoring | `@InnoFlow`, `Reducer`, `Reduce`, `CombineReducers` | 상태 전환 로직을 reducer body로 정의 |
-| Child composition | `Scope`, `IfLet`, `IfCaseLet`, `ForEachReducer` | 자식 feature를 명시적으로 합성 |
-| SwiftUI runtime | `Store`, `ScopedStore`, `SelectedStore`, `@BindableField` | SwiftUI에서 상태를 관찰하고 파생 projection을 다루는 계층 |
-| Effect runtime | `EffectTask`, `EffectContext`, FIFO queue | 비동기 작업, 취소, 시간 제어 |
-| Phase-driven modeling | `PhaseMap`, `PhaseTransitionGraph`, `ActionMatcher` | 의미 있는 phase를 가진 feature의 전환 계약 |
-| Testing / observability | `TestStore`, `InnoFlowTesting`, `StoreInstrumentation` | 결정론적 테스트와 runtime 계측 |
-
-반대로 아래는 InnoFlow가 의도적으로 소유하지 않습니다.
+소유하지 말아야 하는 것:
 
 - concrete navigation stack
-- transport, reconnect, session lifecycle
-- construction-time dependency graph
-- window, scene, immersive space 같은 앱 런타임 경계
+- URLSession이나 network retry
+- DI graph construction
+- SwiftUI layout
+- app lifecycle, scene, window
 
-이 경계가 중요한 이유는 단순합니다. InnoFlow가 모든 앱 상태를 가져가면 오히려 reducer가 거대한 orchestration 허브가 됩니다. `3.0`의 문서들은 이걸 분명히 피합니다.
+이 경계가 중요합니다. InnoFlow를 navigation과 networking까지 다루는 거대한 app framework처럼 쓰면 장점이 흐려집니다. InnoFlow는 작게 둘수록 선명합니다. feature `Logic` 타깃 안에서 상태 전이를 책임지고, 나머지는 바깥 경계로 내보내는 것이 좋습니다.
 
----
+## 설치와 기본 authoring surface
 
-## 공식 authoring surface
+```swift
+dependencies: [
+    .package(url: "https://github.com/InnoSquadCorp/InnoFlow.git", from: "4.0.0")
+]
+```
 
-`3.0`에서 가장 먼저 바뀐 감각은 여기입니다. 이제 feature를 설명할 때 `reduce(into:action:)`를 먼저 보여주기보다 `body` 기반 reducer composition을 보여주는 것이 맞습니다.
+제품은 역할별로 나누어 가져갑니다.
 
-### `@InnoFlow` + `var body: some Reducer`
+```swift
+.target(
+    name: "YourFeatureLogic",
+    dependencies: ["InnoFlow"]
+)
+
+.target(
+    name: "YourFeatureUI",
+    dependencies: ["InnoFlowSwiftUI"]
+)
+
+.testTarget(
+    name: "YourFeatureTests",
+    dependencies: ["InnoFlowTesting"]
+)
+```
+
+InnoFlow 4.x의 권장 authoring surface는 `@InnoFlow`와 `var body: some Reducer<State, Action>`입니다.
 
 ```swift
 import InnoFlow
 
 @InnoFlow
 struct CounterFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    var count = 0
-    @BindableField var step = 1
-  }
-
-  enum Action: Equatable, Sendable {
-    case increment
-    case decrement
-    case setStep(Int)
-  }
-
-  var body: some Reducer<State, Action> {
-    Reduce { state, action in
-      switch action {
-      case .increment:
-        state.count += state.step
-        return .none
-
-      case .decrement:
-        state.count -= state.step
-        return .none
-
-      case .setStep(let step):
-        state.step = max(1, step)
-        return .none
-      }
-    }
-  }
-}
-```
-
-이게 `3.0`에서 말하는 공식 feature authoring입니다.
-
-- feature는 `State`, `Action`, `body`를 가진다
-- `@InnoFlow`는 이 구조를 기반으로 필요한 reducer entry point를 생성한다
-- 사람이 직접 써야 하는 부분은 composition과 domain logic이지, boilerplate가 아니다
-
-### `Reduce`는 primitive reducer다
-
-`Reduce`는 closure 기반 primitive reducer입니다. InnoFlow의 다른 composition surface도 결국 여기에 얹힙니다.
-
-```swift
-Reduce<State, Action> { state, action in
-  // mutate state
-  // return EffectTask<Action>
-}
-```
-
-핵심은 여전히 같습니다. 상태는 reducer 안에서만 바뀌고, effect는 `EffectTask<Action>`로 돌아옵니다. 다만 `3.0`은 그 진입점을 `body` composition으로 통일했습니다.
-
----
-
-## Composition surface
-
-InnoFlow 3.0은 여러 authoring 스타일을 늘리는 대신, 작은 composition surface를 공식 경로로 고정했습니다.
-
-### `CombineReducers`
-
-부모 logic과 보조 reducer를 선언 순서대로 결합합니다.
-
-```swift
-var body: some Reducer<State, Action> {
-  CombineReducers {
-    Reduce { state, action in
-      switch action {
-      case .load:
-        state.isLoading = true
-        return .send(.child(.start))
-      case .child(.finished):
-        state.isLoading = false
-        return .none
-      default:
-        return .none
-      }
+    struct State: Equatable, Sendable, DefaultInitializable {
+        var count = 0
     }
 
-    AnalyticsReducer()
-  }
-}
-```
+    enum Action: Equatable, Sendable {
+        case increment
+        case decrement
+    }
 
-### `Scope`
-
-항상 존재하는 child state를 부모 action 공간으로 끌어올릴 때 씁니다.
-
-```swift
-@InnoFlow
-struct ParentFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    var child = ChildFeature.State()
-    var isLoading = false
-  }
-
-  enum Action: Equatable, Sendable {
-    case load
-    case child(ChildFeature.Action)
-  }
-
-  var body: some Reducer<State, Action> {
-    CombineReducers {
-      Reduce { state, action in
-        switch action {
-        case .load:
-          state.isLoading = true
-          return .send(.child(.start))
-        case .child(.finished):
-          state.isLoading = false
-          return .none
-        default:
-          return .none
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .increment:
+                state.count += 1
+                return .none
+            case .decrement:
+                state.count -= 1
+                return .none
+            }
         }
-      }
-
-      Scope(
-        state: \.child,
-        action: .childCasePath,
-        reducer: ChildFeature()
-      )
     }
-  }
 }
 ```
 
-`@InnoFlow`가 붙어 있으면 `case child(ChildFeature.Action)` 같은 케이스에서 `childCasePath`를 자동 합성해 줍니다.
+## Best practice 1. `Logic` 타깃 안에만 둡니다
 
-### `IfLet`, `IfCaseLet`, `ForEachReducer`
+InnoSample은 leaf feature를 `Interface / Logic / UI / Router / Testing / Tests`로 나눕니다. 이때 InnoFlow는 `Logic` 타깃에만 들어갑니다.
 
-이 세 가지는 child composition의 조건부/컬렉션 버전입니다.
+이 배치가 주는 이점은 큽니다.
 
-- `IfLet`: optional child state
-- `IfCaseLet`: enum case로 열리는 child state
-- `ForEachReducer`: collection row reducer
+- reducer가 SwiftUI layout을 모릅니다.
+- reducer가 InnoRouter route stack을 모릅니다.
+- reducer가 network client를 직접 만들지 않습니다.
+- UI는 state를 표시하고 action을 보낼 뿐입니다.
+- Router는 reducer가 만든 intent를 소비할 뿐입니다.
 
-이 surface가 중요한 이유는 "child reducer를 어떻게 올릴지"가 더 이상 팀마다 다르게 흩어지지 않기 때문입니다.
+즉 InnoFlow는 "feature의 생각"을 맡고, SwiftUI는 "그 생각을 보여주는 화면"을 맡습니다.
 
----
+## Best practice 2. dependency는 reducer 입력으로 제한합니다
 
-## SwiftUI runtime
-
-### `Store`는 SwiftUI-first runtime이다
-
-기본 사용법은 여전히 단순합니다.
+InnoSample의 `PeopleFeatureReducer`는 use case를 dependency bundle로 받습니다.
 
 ```swift
-import InnoFlow
-import SwiftUI
-
-struct CounterView: View {
-  @State private var store: Store<CounterFeature>
-
-  init(store: Store<CounterFeature> = Store(reducer: CounterFeature())) {
-    _store = State(initialValue: store)
-  }
-
-  var body: some View {
-    VStack(spacing: 20) {
-      Text("Count: \(store.count)")
-        .font(.largeTitle)
-
-      HStack(spacing: 24) {
-        Button("−") { store.send(.decrement) }
-        Button("+") { store.send(.increment) }
-      }
-
-      Stepper(
-        "Step: \(store.step)",
-        value: store.binding(\.$step, send: CounterFeature.Action.setStep)
-      )
-    }
-  }
-}
-```
-
-여기서 바뀐 포인트는 binding 문법입니다. `3.0` 기준 문서는 projected key path를 사용합니다.
-
-- 예전 설명: `store.binding(\.step, ...)`
-- 현재 surface: `store.binding(\.$step, ...)`
-
-binding도 의도적으로 explicit opt-in입니다. `@BindableField`가 붙은 프로퍼티만 SwiftUI에서 바인딩할 수 있습니다.
-
-### `ScopedStore`
-
-mutable child flow는 `ScopedStore`로 가져갑니다.
-
-```swift
-let child = store.scope(state: \.child, action: .childCasePath)
-```
-
-이건 "부모 상태 일부를 자식 뷰에 그냥 넘긴다"는 감각보다, 자식 feature에 맞는 mutable scope를 별도로 만든다는 개념에 가깝습니다.
-
-### `SelectedStore`
-
-반대로 read-only derived value는 `SelectedStore`가 공식 경로입니다.
-
-```swift
-let summary = store.select(dependingOn: (\.profile, \.permissions)) { profile, permissions in
-  DashboardBadge(
-    title: profile.name,
-    isReady: profile.isReady && permissions.isReady
-  )
-}
-```
-
-`SelectedStore`가 중요한 이유는 단순 memoization이 아니라, 큰 SwiftUI 뷰에서 비싼 `Equatable` projection만 선택적으로 refresh하게 만들기 때문입니다.
-
-선택 기준은 이렇습니다.
-
-- mutable child flow면 `ScopedStore`
-- read-only projection이면 `SelectedStore`
-- 의존 slice를 1~3개로 명시할 수 있으면 `select(dependingOn:)`
-- 그게 안 되면 `select { ... }`를 always-refresh fallback으로 사용
-
-### Preview
-
-현재 canonical preview entry point는 `Store.preview(...)`입니다.
-
-```swift
-#Preview("Counter") {
-  CounterView(
-    store: .preview(
-      reducer: CounterFeature(),
-      initialState: .init(count: 3, step: 2)
-    )
-  )
-}
-```
-
-preview 전용 초기화를 production wiring에 섞지 않게 하려는 의도가 여기에도 드러납니다.
-
----
-
-## Effect runtime
-
-`EffectTask<Action>`는 여전히 effect DSL의 중심입니다.
-
-- `.none`
-- `.send(action)`
-- `.run { send, context in ... }`
-- `.merge(...)`
-- `.concatenate(...)`
-- `.cancel(id)`
-- `.cancellable(id:cancelInFlight:)`
-- `.debounce(id:for:)`
-- `.throttle(id:for:leading:trailing:)`
-- `.animation(_:)`
-
-하지만 `3.0`에서 중요한 변화는 DSL 목록보다 runtime contract입니다.
-
-### `EffectContext`
-
-새 코드에서는 `.run { send, context in ... }` 스타일을 우선 쓰는 것이 맞습니다.
-
-```swift
-return .run { send, context in
-  do {
-    try await context.sleep(for: .milliseconds(300))
-    try await context.checkCancellation()
-    await send(.finished)
-  } catch is CancellationError {
-    return
-  }
-}
-```
-
-이유는 명확합니다.
-
-- `StoreClock`가 debounce/throttle과 effect delay를 함께 제어
-- 테스트에서 wall clock 의존을 줄임
-- cancellation check를 ad-hoc하게 흩뿌리지 않아도 됨
-
-### FIFO queue semantics
-
-`Store`는 reducer input과 effect follow-up action을 단일 FIFO queue로 처리합니다.
-
-| 동작 | 의미 |
-|---|---|
-| `.send` | 즉시 follow-up action처럼 보이지만 reducer-reentrant가 아니라 queue에 들어감 |
-| `.run` | suspension boundary 이후 같은 queue로 다시 진입 |
-| `.concatenate` | 선언 순서 유지 |
-| `.merge` | 자식 completion 순서 기준 |
-
-즉, InnoFlow는 effect ordering을 암묵적 재진입에 맡기지 않고 문서화된 contract로 고정합니다.
-
-### `StoreInstrumentation`
-
-운영 환경 observability도 공식 surface가 생겼습니다.
-
-```swift
-let instrumentation: StoreInstrumentation<Feature.Action> = .combined(
-  .osLog(logger: logger),
-  .sink { event in
-    switch event {
-    case .runStarted:
-      metrics.increment("feature.effect.run_started")
-    case .runFinished:
-      metrics.increment("feature.effect.run_finished")
-    case .actionEmitted:
-      metrics.increment("feature.effect.emitted")
-    case .actionDropped:
-      metrics.increment("feature.effect.dropped")
-    case .effectsCancelled:
-      metrics.increment("feature.effect.cancelled")
-    }
-  }
-)
-```
-
-핵심은 vendor SDK를 core reducer semantics에 섞지 않고 `sink`, `osLog`, `combined` 같은 확장 지점으로 분리했다는 점입니다.
-
----
-
-## Phase-driven modeling
-
-`3.0`에서 가장 크게 체감되는 새 장은 여기입니다. 다만 오해하면 안 됩니다.
-
-> `PhaseMap`은 runtime phase ownership layer이고, `PhaseTransitionGraph`는 topology validation 도구입니다.
-
-즉, InnoFlow가 generic FSM runtime으로 변한 것은 아닙니다.
-
-### `PhaseMap`
-
-```swift
-@InnoFlow
-struct ItemsFeature {
-  struct State: Equatable, Sendable, DefaultInitializable {
-    enum Phase: Hashable, Sendable {
-      case idle
-      case loading
-      case loaded
-      case failed
+@InnoFlow(phaseManaged: true)
+struct PeopleFeatureReducer {
+    struct Dependencies: Sendable {
+        let loadPeople: @Sendable () async throws -> [UserSummary]
     }
 
-    var phase: Phase = .idle
-    var items: [Item] = []
-    var errorMessage: String?
-  }
+    struct State: Equatable, Sendable, DefaultInitializable {
+        enum Phase: Hashable, Sendable {
+            case idle
+            case loading
+            case loaded
+            case failed
+        }
 
-  enum Action: Equatable, Sendable {
-    case load
-    case _loaded([Item])
-    case _failed(String)
-  }
-
-  static var phaseMap: PhaseMap<State, Action, State.Phase> {
-    PhaseMap(\.phase) {
-      From(.idle) {
-        On(.load, to: .loading)
-      }
-      From(.loading) {
-        On(Action.loadedCasePath, to: .loaded)
-        On(Action.failedCasePath, to: .failed)
-      }
-      From(.loaded) {
-        On(.load, to: .loading)
-      }
-      From(.failed) {
-        On(.load, to: .loading)
-      }
+        var phase: Phase = .idle
+        var isLoading = false
+        var people: [UserSummary] = []
+        var errorMessage: String?
+        var pendingSettingsRequest: PeopleSettingsRequest?
     }
-  }
 
-  static var phaseGraph: PhaseTransitionGraph<State.Phase> {
-    phaseMap.derivedGraph
-  }
-
-  var body: some Reducer<State, Action> {
-    let phaseMap: PhaseMap<State, Action, State.Phase> = Self.phaseMap
-
-    return Reduce { state, action in
-      switch action {
-      case .load:
-        return .none
-      case ._loaded(let items):
-        state.items = items
-        return .none
-      case ._failed(let message):
-        state.errorMessage = message
-        return .none
-      }
-    }
-    .phaseMap(phaseMap)
-  }
+    let dependencies: Dependencies
 }
 ```
 
-이 모델에서 중요한 규칙은 다음입니다.
+여기서 reducer는 repository도, network client도, DI container도 모릅니다. `loadPeople`이라는 feature가 이해할 수 있는 action만 압니다.
 
-- `PhaseMap`은 base reducer 뒤에서 실행된다
-- `PhaseMap`이 활성화되면 base reducer가 owned phase를 직접 바꾸지 않는 것이 원칙이다
-- unmatched phase/action pair는 기본적으로 legal no-op이다
-- stricter coverage는 runtime이 아니라 test에서 opt-in한다
+이것이 실무에서 중요한 이유는 테스트 때문입니다. reducer test는 network stub이 아니라 `loadPeople` closure를 바꿔서 성공/실패/지연 케이스를 검증할 수 있습니다.
 
-### 언제 써야 하나
+## Best practice 3. phase를 명시적으로 모델링합니다
 
-- `idle -> loading -> loaded`처럼 phase enum이 이미 있을 때
-- legal transition이 business contract의 일부일 때
-- `state.phase = ...`가 reducer 여러 branch에 퍼지고 있을 때
-
-### 언제 쓰지 말아야 하나
-
-- route stack 대체
-- session lifecycle
-- reconnect/transport retry
-- dependency/container wiring
-- 단순 effect bookkeeping
-
-### `PhaseTransitionGraph`
-
-`PhaseTransitionGraph`는 graph topology validation에 집중합니다.
+화면이 복잡해질수록 `isLoading`, `errorMessage`, `hasLoaded` 같은 Boolean 조합은 쉽게 꼬입니다. InnoFlow 4.x에서는 `phaseManaged`와 `PhaseMap`을 통해 상태 전이의 의도를 더 분명하게 둘 수 있습니다.
 
 ```swift
-let report = ItemsFeature.phaseGraph.validationReport(
-  allPhases: [.idle, .loading, .loaded, .failed],
-  root: .idle,
-  terminalPhases: [.loaded]
-)
-
-precondition(report.issues.isEmpty)
-```
-
-payload가 있는 action 기준으로 phase를 나눠야 할 때는 `ActionMatcher`와 case path 기반 `On(...)` 규칙을 우선 쓰는 것이 현재 문서가 권장하는 방향입니다.
-
-여기서 graph는 "정적 계약을 검증"하는 역할입니다. guard-bearing transition metadata까지 이 graph에 욱여넣지 않는 것도 `3.0` 문서가 강조하는 설계 의도입니다.
-
-`validatePhaseTransitions(...)`는 남아 있지만, 새 글에서는 backward compatibility로만 언급하고 canonical path로 추천하지 않습니다.
-
----
-
-## Testing
-
-`InnoFlowTesting`의 `TestStore`는 여전히 핵심이지만, `3.0`에서는 phase-aware testing이 더 선명해졌습니다.
-
-```swift
-import InnoFlowTesting
-
-@Test
-@MainActor
-func loadFlow() async {
-  let store = TestStore(reducer: ItemsFeature())
-
-  let phaseMap: PhaseMap<ItemsFeature.State, ItemsFeature.Action, ItemsFeature.State.Phase> =
-    ItemsFeature.phaseMap
-
-  await store.send(.load, through: phaseMap) {
-    $0.phase = .loading
-  }
-
-  await store.receive(._loaded(items), through: phaseMap) {
-    $0.phase = .loaded
-    $0.items = items
-  }
+static var phaseMap: PhaseMap<State, Action, State.Phase> {
+    PhaseMap(\State.phase) {
+        From(.idle) {
+            On(.onAppear, to: .loading)
+            On(.refresh, to: .loading)
+        }
+        From(.loading) {
+            On(Action.peopleLoadedCasePath, to: .loaded)
+            On(Action.peopleFailedCasePath, to: .failed)
+        }
+        From(.loaded) {
+            On(.refresh, to: .loading)
+        }
+    }
 }
 ```
 
-여기서 포인트는 `through: phaseMap`입니다. phase-heavy feature는 reducer 테스트와 phase ownership 검증을 같은 surface에서 다룹니다.
+phase는 UI 상태 이름이 아니라 feature의 진행 상태입니다. 이 관점으로 보면 loading indicator, retry button, empty state는 phase에서 파생되는 표현이 됩니다.
 
-추가로 기억할 만한 점은 이렇습니다.
+## Best practice 4. async effect는 취소 정책까지 같이 둡니다
 
-- parent `TestStore`를 `scope(state:action:)`해서 child 테스트를 이어갈 수 있다
-- `StoreClock.manual(...)`로 debounce/throttle과 effect delay를 제어할 수 있다
-- state mismatch diagnostics가 diff 중심으로 정리되어 있다
-
-즉, 테스트도 "effect가 어떻게 돌았는가"보다 "문서화된 transition contract를 지키는가"에 더 가까워졌습니다.
-
----
-
-## 언제 무엇을 쓰면 될까요?
-
-| 상황 | 권장 surface |
-|---|---|
-| 단순 feature logic | `@InnoFlow` + `Reduce` |
-| 부모/자식 조합 | `CombineReducers` + `Scope` |
-| optional child | `IfLet` |
-| enum-backed child | `IfCaseLet` |
-| row collection | `ForEachReducer` |
-| mutable child flow | `ScopedStore` |
-| read-only expensive projection | `SelectedStore` |
-| phase-heavy feature | `PhaseMap` + `phaseMap.derivedGraph` |
-| runtime observability | `StoreInstrumentation` |
-| preview/review 환경 | `Store.preview(...)` |
-
-이 표만 봐도 `3.0`의 의도가 드러납니다. InnoFlow는 one big store pattern을 강요하는 프레임워크가 아니라, reducer composition과 state ownership을 작게 나눈 뒤 SwiftUI runtime이 그것을 안정적으로 실행하도록 돕는 프레임워크입니다.
-
----
-
-## 설치와 요구사항
+비동기 loading은 단순히 `Task {}`를 만드는 문제가 아닙니다. refresh가 연속으로 들어오면 이전 요청을 취소할지, 중복 요청을 허용할지 결정해야 합니다.
 
 ```swift
-dependencies: [
-  .package(url: "https://github.com/InnoSquadCorp/InnoFlow.git", from: "3.0.0")
-]
+private func loadPeople() -> EffectTask<Action> {
+    let loadPeople = dependencies.loadPeople
+
+    return .run { send, _ in
+        do {
+            let people = try await loadPeople()
+            await send(.peopleLoaded(people))
+        } catch {
+            await send(.peopleFailed(error.localizedDescription))
+        }
+    }
+    .cancellable("people-feature-load", cancelInFlight: true)
+}
 ```
 
-현재 패키지 요구사항은 다음과 같습니다.
+이 코드는 loading effect와 cancel policy를 한곳에 둡니다. view의 `onAppear`나 button action에 흩어진 `Task`보다 리뷰하기 쉽고 테스트하기도 쉽습니다.
 
-- iOS 18+
-- macOS 15+
-- tvOS 18+
-- watchOS 11+
-- visionOS 2+
-- Swift tools 6.2
+## Best practice 5. navigation은 intent까지만 만듭니다
 
-테스트 타깃에서 `TestStore`, `ManualTestClock` 등을 쓰려면 `InnoFlowTesting`도 함께 추가하면 됩니다.
+InnoFlow reducer가 route stack을 직접 조작하면 feature logic이 navigation framework에 묶입니다. InnoSample은 이 대신 one-shot intent를 state에 남깁니다.
 
----
+```swift
+case .openSettings(let request):
+    state.pendingSettingsRequest = PeopleSettingsRequest(request: request)
+    return .none
+```
 
-## 마무리
+그 다음 `PeopleFeatureCoordinator`가 이 intent를 소비하고, 상위 `EntireTabCoordinator`가 실제 sibling feature 이동을 중재합니다.
 
-지금의 InnoFlow를 한 문장으로 요약하면 이렇습니다.
+이 구조가 좋은 이유는 명확합니다.
 
-> InnoFlow는 SwiftUI 상태관리 라이브러리라기보다, business/domain transition을 reducer composition과 explicit runtime contract로 정리하는 framework입니다.
+- reducer는 "settings로 가고 싶다"는 intent만 표현합니다.
+- coordinator는 그 intent를 navigation command로 바꿉니다.
+- sibling feature import는 상위 coordinator에만 모입니다.
 
-그래서 `3.0`에서 특히 좋아진 점은 다음과 같습니다.
+InnoFlow와 [`InnoRouter`]({% post_url 2026-02-23-innorouter-swiftui-navigation %})가 서로 침범하지 않는 지점입니다.
 
-1. feature authoring이 `body` 기반 reducer composition으로 명확해졌습니다.
-2. child composition surface가 `Scope` 계열로 정리됐습니다.
-3. `SelectedStore`, `Store.preview`, `StoreInstrumentation`처럼 SwiftUI 운영 surface가 선명해졌습니다.
-4. `PhaseMap`과 `PhaseTransitionGraph`가 phase-heavy feature의 계약을 더 잘 드러냅니다.
-5. navigation, session, dependency graph ownership을 프레임워크 바깥에 남겨 경계가 더 깨끗해졌습니다.
+## 도입했을 때 얻는 장점
 
-상태가 복잡하다고 해서 모든 앱 흐름을 하나의 giant state machine으로 밀어넣고 싶지는 않을 때, InnoFlow 3.0은 꽤 좋은 균형점을 제공합니다.
+InnoFlow를 잘 쓰면 feature logic이 다음 성질을 갖습니다.
 
-## 참고 자료
+- 상태 전이가 한 파일에서 읽힙니다.
+- async loading과 error path가 action으로 드러납니다.
+- UI 없이 reducer만 테스트할 수 있습니다.
+- navigation intent를 business state와 분리할 수 있습니다.
+- feature가 network/DI/router 구현을 직접 알지 않습니다.
+- `Reduce`, `Scope`, `IfLet`, `ForEachReducer`로 큰 feature를 작게 쪼갤 수 있습니다.
 
-- [InnoFlow GitHub 저장소](https://github.com/InnoSquadCorp/InnoFlow)
-- [Architecture Contract](https://github.com/InnoSquadCorp/InnoFlow/blob/main/ARCHITECTURE_CONTRACT.md)
-- [Phase-Driven Modeling](https://github.com/InnoSquadCorp/InnoFlow/blob/main/PHASE_DRIVEN_MODELING.md)
-- [Canonical Sample App](https://github.com/InnoSquadCorp/InnoFlow/tree/main/Examples/InnoFlowSampleApp)
+특히 SwiftUI 앱에서 이 장점은 큽니다. SwiftUI는 view 갱신을 잘하지만, feature의 business state ownership까지 자동으로 정리해 주지는 않습니다. InnoFlow는 그 빠진 경계를 채웁니다.
+
+## 언제 쓰면 좋은가
+
+InnoFlow는 이런 앱에 잘 맞습니다.
+
+- 화면마다 loading/error/retry가 반복되는 앱
+- feature test를 view 없이 작성하고 싶은 앱
+- SwiftUI view에서 business logic을 덜어내고 싶은 앱
+- TCA만큼 큰 app framework는 부담스럽지만 reducer 기반 구조는 원하는 팀
+- navigation과 networking은 별도 경계로 분리하고 싶은 팀
+
+반대로 아주 작은 화면이나 일회성 form에는 과할 수 있습니다. 상태 전이가 몇 줄이면 `@State`와 `Observable`만으로 충분합니다.
+
+## InnoSample에서의 결론
+
+[`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice %})에서 InnoFlow는 feature logic을 담당합니다.
+
+- `PeopleFeatureLogic`은 사람 목록 loading과 settings 이동 intent를 관리합니다.
+- `PostsFeatureLogic`은 posts loading과 highlights modal intent를 관리합니다.
+- `SettingsFeatureLogic`은 todos loading과 people 이동 intent를 관리합니다.
+- `Router`는 이 intent를 navigation으로 바꿉니다.
+- `App`과 `Layers`는 reducer 내부를 모릅니다.
+
+이 배치가 InnoFlow의 가장 좋은 사용법입니다. **상태 전이는 reducer에, 화면 이동은 router에, 의존성 생성은 DI container에 둡니다.** 그렇게 나누면 SwiftUI feature는 더 테스트 가능하고, 더 예측 가능하며, 더 오래 유지되는 구조가 됩니다.

--- a/_posts/2026-02-23-innonetwork-type-safe-networking-en.md
+++ b/_posts/2026-02-23-innonetwork-type-safe-networking-en.md
@@ -1,338 +1,217 @@
 ---
-title: "InnoNetwork: A type-safe networking framework for Swift Concurrency"
+title: "InnoNetwork Best Practices: Designing Swift Concurrency Networking Boundaries"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innonetwork-type-safe-networking
 lang: en
-categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, networking, async-await, swift-concurrency, clean-architecture, type-safe]
+description: "Why InnoNetwork is useful, how to isolate Swift Concurrency networking policy inside a Remote layer, and how InnoSample applies that boundary."
+categories: [iOS, Swift, Networking]
+tags: [swift, iOS, networking, async-await, swift-concurrency, clean-architecture, type-safe, api]
 author: ethan
 toc: true
 comments: true
 ---
 
-## Introduction
+## Why networking gets hard in production apps
 
-In the earlier versions of this post, I described `InnoNetwork` mostly as "a type-safe HTTP client built on Swift Concurrency." That is still true, but it no longer describes the full public surface of `3.0.1`.
+Network code looks simple when it starts with `URLSession.data(for:)`. Production apps quickly need more.
 
-The package now exposes three distinct products:
+- Headers and timeout policies vary by endpoint.
+- Retry is added without respecting HTTP method safety.
+- Auth refresh runs multiple times under concurrent failures.
+- Error classification differs by feature.
+- Logging and tracing are bolted onto call sites.
+- DTOs, domain models, and repositories blur together.
 
-- `InnoNetwork`
-- `InnoNetworkDownload`
-- `InnoNetworkWebSocket`
+[`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork) is not just a URLSession wrapper. It is a Swift Concurrency request pipeline with typed endpoint definitions, client configuration, retry, interceptors, logging, cache, trust, and test support.
 
-And the public contract is no longer just about sending HTTP requests. It also includes **explicit configuration entry points, transport policy, event delivery, durability, and reconnect behavior**.
+Its strongest appeal is that **network execution policy can stay outside features while endpoint contracts remain typed.**
 
-This post revisits `InnoNetwork` from that perspective.
+## The boundary InnoNetwork should own
 
-## Why revisit it now
+InnoNetwork should own:
 
-The important shift in `3.0.x` is not just "more examples." It is that the framework now has clearer operational boundaries:
+- typed endpoint definitions
+- request and response decoding
+- retry, timeout, and transport policy
+- request and response interceptors
+- auth refresh and coalescing
+- logging, tracing, and event observation
+- download, websocket, persistent cache, and trust surfaces
+- consumer test support
 
-- `safeDefaults` is the recommended entry point
-- `advanced` is where operational tuning belongs
-- download and websocket lifecycle are separated into dedicated products
-- Protocol Buffers support moved into a separate `InnoNetworkProtobuf` package
-- bounded buffering, append-log durability, and reconnect taxonomy are now part of the documented runtime model
+It should not own:
 
-So the right way to explain `InnoNetwork` today is not only "how to send a request," but **which network lifecycle belongs to which surface**.
+- domain entity design
+- repository business policy
+- feature loading state
+- navigation
+- dependency graph construction
 
-## Product structure and ownership boundary
+InnoNetwork answers "how does this app call external APIs?" How the result becomes app meaning belongs to `Data` and `Domain`.
 
-It helps to start with the product split.
+## Product selection
 
-### `InnoNetwork`
+InnoNetwork 4.x exposes products by role.
 
-This is the core request/response module.
+- `InnoNetwork`: core typed request pipeline
+- `InnoNetworkAuthAWS`: AWS SigV4 reference signer
+- `InnoNetworkDownload`: foreground/background download lifecycle
+- `InnoNetworkWebSocket`: realtime connection lifecycle
+- `InnoNetworkPersistentCache`: on-disk response cache
+- `InnoNetworkTrust`: public-key pinning evaluation
+- `InnoNetworkOpenAPI`: generated-client transport support
+- `InnoNetworkTestSupport`: consumer test helpers
 
-- `APIDefinition`
-- `MultipartAPIDefinition`
-- `DefaultNetworkClient`
-- `NetworkConfiguration`
-- `TrustPolicy`
-- `RetryPolicy`
-
-### `InnoNetworkDownload`
-
-This product owns download lifecycle.
-
-- `DownloadConfiguration`
-- `DownloadManager`
-- progress, completion, and failure streams
-- foreground and background orchestration
-
-### `InnoNetworkWebSocket`
-
-This product owns connection-oriented realtime flows.
-
-- `WebSocketConfiguration`
-- `WebSocketManager`
-- reconnect behavior
-- heartbeat and pong timeout
-- event streams
-
-That separation is important. `InnoNetwork` is not one giant "network utility" module. It is a framework family that splits surfaces by transport lifecycle.
-
-## Install
-
-The base package installation for `3.0.1` starts here.
+Most apps start with `InnoNetwork`.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1")
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", .upToNextMinor(from: "4.0.0"))
 ]
 ```
 
-## Core request model
+If you only use the stable API ledger, `.upToNextMajor(from: "4.0.0")` may be appropriate. If you use provisionally stable surfaces, review `CHANGELOG.md` before taking minor upgrades.
 
-The core modeling primitive is still `APIDefinition`.
+## Best practice 1. Keep it inside `Remote`
 
-```swift
-import Foundation
-import InnoNetwork
+When features import the network client directly, transport policy leaks throughout the app. InnoSample avoids that.
 
-struct User: Decodable, Sendable {
-    let id: Int
-    let name: String
-}
+The current layering is:
 
-struct GetUser: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = User
+- `Remote`: InnoNetwork client, request definitions, interceptors, remote failure mapping
+- `Data`: remote data source contracts and repository implementations
+- `Domain`: repository protocols, entities, and use cases
+- `Feature`: use case calls only
 
-    var method: HTTPMethod { .get }
-    var path: String { "/users/1" }
-}
-```
+`PeopleFeature` does not know `NetworkClient`. It calls `FetchPeopleUseCase`; the HTTP call finishes inside `Remote`.
 
-Execution goes through `DefaultNetworkClient`.
+## Best practice 2. Build client policy in one place
+
+Production network policy should not be scattered endpoint by endpoint. InnoSample builds the client in `RemoteClientFactory`.
 
 ```swift
-let client = DefaultNetworkClient(
-    configuration: .safeDefaults(
-        baseURL: URL(string: "https://api.example.com/v1")!
-    )
-)
-
-let user = try await client.request(GetUser())
-print(user.name)
-```
-
-One meaningful change from older examples is that `APIConfigure` is no longer the main entry point for configuration in the docs. In `3.0.x`, the dominant style is **explicit configuration objects**.
-
-## `safeDefaults` and `advanced`
-
-The strongest message in the current documentation is simple:
-
-> stay on `safeDefaults` unless you have a real operational reason to tune behavior
-
-### Recommended starting point
-
-```swift
-let client = DefaultNetworkClient(
-    configuration: NetworkConfiguration.safeDefaults(
-        baseURL: URL(string: "https://api.example.com")!
-    )
-)
-```
-
-### Move to `advanced` only when needed
-
-```swift
-let configuration = NetworkConfiguration.advanced(
-    baseURL: URL(string: "https://api.example.com")!
-) { builder in
-    builder.timeout = 30
-    builder.retryPolicy = ExponentialBackoffRetryPolicy()
-    builder.trustPolicy = .systemDefault
-}
-
-let client = DefaultNetworkClient(configuration: configuration)
-```
-
-That distinction matters because `advanced` is public and supported, but its tuning values are not the main compatibility story. The recommended public path is still `safeDefaults`.
-
-## Transport and operational surface
-
-To understand `InnoNetwork 3.x`, request and response modeling is only one part of the story.
-
-### `RetryPolicy`
-
-Retry behavior is isolated into policy rather than leaking into business logic.
-
-- `RetryPolicy`
-- `ExponentialBackoffRetryPolicy`
-
-### `TrustPolicy`
-
-Trust evaluation is also an explicit public surface.
-
-- `.systemDefault`
-- public key pinning
-
-### `EventDeliveryPolicy`
-
-This is one of the clearest signs of the `3.x` direction. Event delivery is not treated as an unbounded implementation detail. It is modeled as a bounded buffering policy with overflow behavior that can be tuned explicitly.
-
-That means the framework gives you a public way to talk about what should happen when event streams start backing up under load.
-
-### `URLQueryEncoder` and `AnyResponseDecoder`
-
-The documentation also makes encoding and decoding behavior more explicit than before.
-
-- `URLQueryEncoder` is the public surface behind deterministic query and form encoding.
-- `AnyResponseDecoder` is one of the public pieces used for explicit decoding strategies.
-
-You may not touch these types every day, but they are still part of the public `3.x` contract and worth naming explicitly.
-
-## Interceptors and request/response policy
-
-Earlier versions of this post made `RequestInterceptor`, `ResponseInterceptor`, and `RetryPolicy` sound like the whole framework. In `3.x`, the tone should be slightly different.
-
-These types still matter:
-
-- `RequestInterceptor`
-- `ResponseInterceptor`
-- `RetryPolicy`
-
-But the more important story is that **request execution happens inside explicit policy boundaries**.
-
-The README and changelog make it clear that request/response execution was reorganized around internal transport policies and explicit decoding strategies. That is essential to the implementation, but in a blog post it is better framed as runtime architecture rather than a stable public contract.
-
-## Download lifecycle
-
-Download behavior belongs to `InnoNetworkDownload`.
-
-```swift
-import Foundation
-import InnoNetworkDownload
-
-let manager = DownloadManager.shared
-let task = await manager.download(
-    url: URL(string: "https://example.com/file.zip")!,
-    toDirectory: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-)
-
-for await event in await manager.events(for: task) {
-    print(event)
-}
-```
-
-The important part is not just "it downloads files." The product is designed around:
-
-- foreground and background orchestration
-- pause, resume, and retry
-- listener retention
-- append-log persistence for durability
-
-So `DownloadManager` is better understood as a **download lifecycle manager** than as a convenience wrapper around `URLSessionDownloadTask`.
-
-You can also move to explicit configuration when needed.
-
-```swift
-let configuration = DownloadConfiguration.advanced { builder in
-    builder.maxConnectionsPerHost = 3
-    builder.maxRetryCount = 2
-}
-```
-
-Again, the pattern is the same: `safeDefaults` first, `advanced` only for concrete tuning needs.
-
-## WebSocket lifecycle
-
-Realtime connection behavior belongs to `InnoNetworkWebSocket`.
-
-```swift
-import Foundation
-import InnoNetworkWebSocket
-
-let task = await WebSocketManager.shared.connect(
-    url: URL(string: "wss://echo.example.com/socket")!
-)
-
-for await event in await WebSocketManager.shared.events(for: task) {
-    print(event)
-}
-```
-
-The main value here is not just connect/send/receive. It is the operational model around:
-
-- reconnect policy
-- handshake-aware close taxonomy
-- reconnect suppression rules
-- heartbeat and pong timeout
-- event delivery policy
-
-So when explaining `WebSocketManager`, it is more accurate to focus on **how it manages failure and reconnect behavior** than on the bare existence of a websocket client.
-
-## Error handling
-
-`InnoNetwork` favors explicit transport errors over opaque failure buckets.
-
-```swift
-do {
-    let user = try await client.request(GetUser())
-    print(user)
-} catch let error as NetworkError {
-    switch error {
-    case .invalidBaseURL(let url):
-        print("Invalid base URL: \(url)")
-    case .invalidRequestConfiguration(let message):
-        print("Invalid request configuration: \(message)")
-    case .statusCode(let response):
-        print("Unexpected status code: \(response.statusCode)")
-    case .objectMapping(let underlying, _):
-        print("Decoding failed: \(underlying)")
-    case .trustEvaluationFailed(let reason):
-        print("Trust evaluation failed: \(reason)")
-    case .cancelled:
-        print("Request cancelled")
-    default:
-        print(error)
+enum RemoteClientFactory {
+    static func makeClient(
+        baseURL: URL,
+        session: URLSessionProtocol = URLSession.shared
+    ) -> any NetworkClient {
+        let configuration = NetworkConfiguration.advanced(
+            baseURL: baseURL,
+            resilience: ResiliencePack(
+                retry: ExponentialBackoffRetryPolicy(
+                    maxRetries: 2,
+                    maxTotalRetries: 2,
+                    retryDelay: 0.4
+                )
+            ),
+            auth: AuthPack(
+                additionalSigners: [
+                    RemoteMetadataInterceptor(environment: .init(baseURL: baseURL)),
+                ],
+                additionalResponseInterceptors: [
+                    RemoteStatusInterceptor(),
+                ]
+            ),
+            transport: TransportPack(
+                timeout: 20.0,
+                cachePolicy: .reloadIgnoringLocalCacheData
+            )
+        )
+        return DefaultNetworkClient(configuration: configuration, session: session)
     }
 }
 ```
 
-`invalidRequestConfiguration` is especially useful because it usually means the request shape and policy do not agree. That is much more actionable than an opaque generic failure.
+Retry, metadata, status handling, and timeout policy are reviewed in one place. Feature call sites stay clean.
 
-## Protocol Buffers are now a separate package
+## Best practice 3. Give endpoints meaningful types
 
-Older versions of this post treated Protocol Buffers support as if it were still part of the main package surface. That is no longer accurate in `3.0.1`.
-
-If you need protobuf request/response support, you now add **`InnoNetworkProtobuf` as a separate package**.
+For simple onboarding, `EndpointBuilder` is a good first path. Once endpoint meaning matters, dedicated `APIDefinition` types become easier to maintain.
 
 ```swift
-dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetworkProtobuf.git", branch: "main")
-]
+import InnoNetwork
+
+protocol RemoteRequest: APIDefinition {
+    var featureName: String { get }
+}
+
+extension RemoteRequest {
+    var method: HTTPMethod { .get }
+
+    var headers: HTTPHeaders {
+        var headers = HTTPHeaders.default
+        headers.update(name: "X-Sample-Feature", value: featureName)
+        return headers
+    }
+
+    var logger: NetworkLogger {
+        RemoteRequestLogger()
+    }
+}
 ```
 
-That is best read as a clearer architectural split between the core transport package and the protobuf adapter layer, not as a missing feature.
+This keeps common headers and logging policy in the remote request layer instead of repeating string-based setup at every call site.
 
-## When to use which surface
+## Best practice 4. Convert errors once at the remote boundary
 
-| Situation | Recommended choice |
-|------|------|
-| standard REST or HTTP APIs | `InnoNetwork` + `NetworkConfiguration.safeDefaults(baseURL:)` |
-| retry, trust, metrics, or event delivery tuning | `NetworkConfiguration.advanced(baseURL:_:)` |
-| file download with lifecycle tracking | `InnoNetworkDownload` + `DownloadManager` |
-| realtime connection with reconnect and heartbeat requirements | `InnoNetworkWebSocket` + `WebSocketManager` |
-| protobuf request or response modeling | `InnoNetwork` + `InnoNetworkProtobuf` |
+Passing `NetworkError` all the way to features exposes transport detail. Erasing everything to `Error` loses useful classification.
 
-## Closing thoughts
+A better shape is to convert network errors to `RemoteFailure` in `Remote`, then translate again as needed in `Data` or `Domain`.
 
-If I had to summarize `InnoNetwork 3.0.1` in one sentence, I would no longer call it only a type-safe HTTP client. A better description is **a networking framework family with explicit operational policy**.
+- InnoNetwork: HTTP, transport, and decoding classification
+- Remote: external API failure meaning
+- Data: repository policy
+- Domain: feature-facing domain error
 
-`APIDefinition` and `DefaultNetworkClient` are still the starting point. But to use `3.x` well, it helps to keep four things in view:
+Features receive app language, not raw transport language, unless they explicitly need it.
 
-- `safeDefaults` is the default path
-- `advanced` is for local operational tuning
-- download and websocket lifecycle belong to separate products
-- protobuf support now lives in a separate package
+## Best practice 5. Test at the URLSession boundary
 
-For a deeper look, I recommend reading these in order:
+InnoNetwork's `URLSessionProtocol` and test support make the remote boundary testable. InnoSample's remote tests use stub sessions to verify requests and response mapping.
 
-1. [README](https://github.com/InnoSquadCorp/InnoNetwork)
-2. [`API_STABILITY.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/API_STABILITY.md)
-3. [`Examples/README.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/Examples/README.md)
-4. [`docs/releases/3.0.1.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/docs/releases/3.0.1.md)
+The important questions are not "does the real internet work?"
+
+- Is the path correct?
+- Are headers applied?
+- Is status failure converted correctly?
+- Is decoding failure classified correctly?
+- Do retry and interceptor ordering match the policy?
+
+Those tests are faster and more stable than UI tests.
+
+## What you gain by adopting it
+
+Used well, InnoNetwork gives you:
+
+- typed endpoint contracts
+- retry/auth/interceptor policy outside feature code
+- more consistent network error classification
+- features that do not know transport implementation
+- testable remote boundaries
+- a consistent family for download, websocket, cache, and trust features
+
+The core value is not "HTTP made easy." The core value is **preventing networking from leaking across your app architecture.**
+
+## When it is a good fit
+
+InnoNetwork is attractive when:
+
+- an app has many endpoints and shared policies
+- auth refresh, retry, timeout, and logging matter
+- feature-level network duplication is growing
+- the team prefers Swift Concurrency and strict error classification
+- download, websocket, persistent cache, or trust features should follow the same package family
+
+For one-off scripts or very small prototypes, plain URLSession may be enough.
+
+## How InnoSample uses it
+
+In [`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice-en %}), InnoNetwork is strongly contained inside `Remote`.
+
+- `RemoteContainer` builds `NetworkClient` and remote data sources.
+- `RemoteClientFactory` owns retry, interceptor, timeout, and logger policy.
+- `RemoteRequest` provides the common request surface.
+- `Data` sees only remote data source protocols.
+- `Domain` and `Feature` do not know InnoNetwork.
+
+That is the best way to use InnoNetwork: **type the networking policy strongly, then keep it at the app boundary.** Features stay simpler, and network policy remains operationally reviewable.

--- a/_posts/2026-02-23-innonetwork-type-safe-networking.md
+++ b/_posts/2026-02-23-innonetwork-type-safe-networking.md
@@ -1,336 +1,219 @@
 ---
-title: "InnoNetwork: Swift Concurrency를 위한 타입 안전 네트워킹 프레임워크"
+title: "InnoNetwork Best Practice: Swift Concurrency 네트워크 경계를 설계하는 법"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innonetwork-type-safe-networking
 lang: ko-KR
-categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, networking, async-await, swift-concurrency, clean-architecture, type-safe]
+description: "InnoNetwork를 왜 써야 하는지, Swift Concurrency 기반 네트워크 정책을 Remote 레이어 안에 어떻게 격리하는 것이 좋은지 설명합니다."
+categories: [iOS, Swift, Networking]
+tags: [swift, iOS, networking, async-await, swift-concurrency, clean-architecture, type-safe, api]
 author: ethan
 toc: true
 comments: true
 ---
 
-## 들어가며
+## 왜 네트워크 코드가 실무에서 어려운가
 
-초기 버전의 `InnoNetwork`를 설명할 때는 보통 "Swift Concurrency 기반 타입 안전 HTTP 클라이언트"라는 표현을 썼습니다. 지금도 틀린 말은 아니지만, `3.0.1` 기준으로는 그 설명만으로 부족합니다.
+네트워크 코드는 처음에는 `URLSession.data(for:)`로 충분해 보입니다. 하지만 운영 앱에서는 곧 다른 문제가 생깁니다.
 
-현재 공개 패키지는 아래 세 제품으로 나뉩니다.
+- endpoint마다 header와 timeout 정책이 달라집니다.
+- retry가 HTTP method의 안전성을 무시하고 붙습니다.
+- auth refresh가 중복 실행됩니다.
+- error classification이 feature마다 달라집니다.
+- logging과 tracing이 뒤늦게 들어오며 호출부가 지저분해집니다.
+- DTO, domain model, repository 경계가 섞입니다.
 
-- `InnoNetwork`
-- `InnoNetworkDownload`
-- `InnoNetworkWebSocket`
+[`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork)는 단순 URLSession wrapper가 아니라, Swift Concurrency 기반의 typed request pipeline입니다. request definition, client configuration, retry, interceptor, logger, cache, trust, test support를 명확한 제품군으로 나눕니다.
 
-그리고 실제 public contract는 단순 HTTP wrapper가 아니라, **명시적인 configuration entry point, transport policy, event delivery, durability, reconnect model**까지 포함합니다.
+핵심 매력은 **네트워크 실행 정책을 feature 밖으로 꺼내고, 타입이 있는 endpoint 계약으로 고정할 수 있다는 점**입니다.
 
-이 글은 그 기준으로 `InnoNetwork`를 다시 정리합니다.
+## InnoNetwork가 소유하는 경계
 
-## 왜 다시 봐야 하나
+InnoNetwork가 소유하기 좋은 것:
 
-`3.0.x`에서 가장 중요한 변화는 "더 많은 endpoint 예제"가 아닙니다. 대신 아래 관점이 또렷해졌습니다.
+- typed endpoint definition
+- request/response decoding
+- retry, timeout, transport policy
+- request/response interceptor
+- auth refresh/coalescing
+- logging, tracing, event observation
+- download, websocket, persistent cache 같은 transport-adjacent feature
+- consumer test support
 
-- `safeDefaults`가 권장 진입점이라는 점
-- `advanced` builder로 운영 정책을 국소적으로 조정한다는 점
-- 다운로드와 웹소켓이 별도 product로 분리되어 있다는 점
-- protobuf가 별도 패키지 `InnoNetworkProtobuf`로 이동했다는 점
-- bounded buffering, append-log durability, reconnect taxonomy 같은 운영 모델이 문서화되었다는 점
+InnoNetwork가 소유하지 말아야 하는 것:
 
-즉, 지금 `InnoNetwork`는 "HTTP 요청 보내는 법"보다 **어떤 네트워크 lifecycle을 어떤 surface로 다룰 것인지**가 더 중요한 프레임워크입니다.
+- domain entity 설계
+- repository business policy
+- feature loading state
+- 화면 이동
+- DI graph construction
 
-## 제품군 구조와 ownership boundary
+즉 InnoNetwork는 "외부 API를 어떻게 호출할 것인가"를 소유합니다. "그 결과를 앱 도메인에서 어떻게 해석할 것인가"는 `Data`와 `Domain`의 일입니다.
 
-먼저 제품 경계를 명확히 보는 게 좋습니다.
+## 제품군 선택
 
-### `InnoNetwork`
+InnoNetwork 4.x는 public product가 역할별로 나뉩니다.
 
-기본 request/response API를 담당합니다.
+- `InnoNetwork`: core typed request pipeline
+- `InnoNetworkAuthAWS`: AWS SigV4 reference signer
+- `InnoNetworkDownload`: foreground/background download lifecycle
+- `InnoNetworkWebSocket`: realtime connection lifecycle
+- `InnoNetworkPersistentCache`: on-disk response cache
+- `InnoNetworkTrust`: public-key pinning evaluation
+- `InnoNetworkOpenAPI`: generated client transport support
+- `InnoNetworkTestSupport`: consumer test helpers
 
-- `APIDefinition`
-- `MultipartAPIDefinition`
-- `DefaultNetworkClient`
-- `NetworkConfiguration`
-- `TrustPolicy`
-- `RetryPolicy`
-
-### `InnoNetworkDownload`
-
-다운로드 lifecycle을 담당합니다.
-
-- `DownloadConfiguration`
-- `DownloadManager`
-- progress / completion / failure event stream
-- foreground / background orchestration
-
-### `InnoNetworkWebSocket`
-
-연결 지향 realtime flow를 담당합니다.
-
-- `WebSocketConfiguration`
-- `WebSocketManager`
-- reconnect policy
-- heartbeat / pong timeout
-- event stream
-
-이 구조 덕분에 `InnoNetwork`는 "모든 네트워크 문제를 하나의 클라이언트에 우겨 넣는 패키지"가 아니라, transport 성격에 따라 surface를 분리한 프레임워크 제품군이 됩니다.
-
-## 설치
-
-기본 설치는 `3.0.1` 기준으로 아래처럼 시작합니다.
+일반 앱의 첫 진입점은 보통 `InnoNetwork`입니다.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1")
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", .upToNextMinor(from: "4.0.0"))
 ]
 ```
 
-## Core Request Model
+앱이 stable ledger만 사용한다면 `.upToNextMajor(from: "4.0.0")`도 선택할 수 있지만, minor 단위로 provisionally stable surface가 발전할 수 있으므로 `CHANGELOG.md`를 같이 확인하는 편이 좋습니다.
 
-기본 요청 모델은 여전히 `APIDefinition`입니다.
+## Best practice 1. 앱 전체가 아니라 `Remote` 레이어에 가둡니다
 
-```swift
-import Foundation
-import InnoNetwork
+InnoNetwork를 feature마다 직접 import하면 네트워크 정책이 앱 전체로 퍼집니다. InnoSample은 이 선택을 피합니다.
 
-struct User: Decodable, Sendable {
-    let id: Int
-    let name: String
-}
+현재 구조는 다음과 같습니다.
 
-struct GetUser: APIDefinition {
-    typealias Parameter = EmptyParameter
-    typealias APIResponse = User
+- `Remote`: InnoNetwork client, request definition, interceptor, remote failure mapping
+- `Data`: remote data source contract와 repository 구현
+- `Domain`: repository protocol, entity, use case
+- `Feature`: use case만 호출
 
-    var method: HTTPMethod { .get }
-    var path: String { "/users/1" }
-}
-```
+이 구조에서 `PeopleFeature`는 `NetworkClient`를 모릅니다. feature는 `FetchPeopleUseCase`만 알고, 실제 HTTP 호출은 `Remote` 안에서 끝납니다.
 
-실행은 `DefaultNetworkClient`가 맡습니다.
+## Best practice 2. client configuration은 한곳에서 조립합니다
+
+운영 네트워크 정책은 endpoint마다 흩어지면 안 됩니다. InnoSample은 `RemoteClientFactory`에서 기본 client를 만듭니다.
 
 ```swift
-let client = DefaultNetworkClient(
-    configuration: .safeDefaults(
-        baseURL: URL(string: "https://api.example.com/v1")!
-    )
-)
-
-let user = try await client.request(GetUser())
-print(user.name)
-```
-
-여기서 중요한 건 예전처럼 별도 `APIConfigure` 타입을 기본 설정 entry point로 두지 않는다는 점입니다. `3.0.x`에서는 **configuration object를 명시적으로 생성하는 방식**이 문서와 예제의 중심입니다.
-
-## `safeDefaults`와 `advanced`
-
-지금 문서에서 가장 강조하는 메시지는 간단합니다.
-
-> 특별한 운영 요구가 없다면 `safeDefaults`에 머문다.
-
-### 권장 시작점
-
-```swift
-let client = DefaultNetworkClient(
-    configuration: NetworkConfiguration.safeDefaults(
-        baseURL: URL(string: "https://api.example.com")!
-    )
-)
-```
-
-### 운영 정책이 필요할 때만 `advanced`
-
-```swift
-let configuration = NetworkConfiguration.advanced(
-    baseURL: URL(string: "https://api.example.com")!
-) { builder in
-    builder.timeout = 30
-    builder.retryPolicy = ExponentialBackoffRetryPolicy()
-    builder.trustPolicy = .systemDefault
-}
-
-let client = DefaultNetworkClient(configuration: configuration)
-```
-
-이 구분이 중요한 이유는, `advanced`는 public API이긴 하지만 숫자나 세부 튜닝 값 자체를 contract로 고정하는 surface는 아니기 때문입니다. 프레임워크가 권장하는 경로는 여전히 `safeDefaults`입니다.
-
-## Transport / Operational Surface
-
-`InnoNetwork`를 `3.x` 기준으로 설명할 때는 request/response shape만이 아니라 운영 surface를 같이 봐야 합니다.
-
-### `RetryPolicy`
-
-재시도는 business code에 흩어지는 로직이 아니라 policy로 분리됩니다.
-
-- `RetryPolicy`
-- `ExponentialBackoffRetryPolicy`
-
-### `TrustPolicy`
-
-신뢰 평가도 명시적인 surface로 노출됩니다.
-
-- `.systemDefault`
-- public key pinning
-
-### `EventDeliveryPolicy`
-
-이 부분이 특히 `3.x`다운 변화입니다. 이벤트 전달은 무한 버퍼에 기대지 않고, **bounded buffering과 overflow policy**를 가진 별도 정책으로 다뤄집니다.
-
-즉, 운영 중에 event stream이 과도하게 밀릴 때 어떤 식으로 처리할지를 public surface에서 조절할 수 있습니다.
-
-### `URLQueryEncoder`와 `AnyResponseDecoder`
-
-문서의 톤을 보면 query/form encoding과 decoding도 점점 더 명시적으로 다뤄집니다.
-
-- `URLQueryEncoder`는 deterministic ordering을 가진 query / form 인코딩 경로를 담당합니다.
-- `AnyResponseDecoder`는 explicit decoding strategy를 구성하는 public surface 중 하나입니다.
-
-둘 다 "일상적으로 직접 만지는 타입"은 아닐 수 있지만, `3.x` public contract를 설명할 때는 존재를 짚고 넘어가는 편이 맞습니다.
-
-## Interceptor와 request/response policy
-
-기존 글에서는 `RequestInterceptor`, `ResponseInterceptor`, `RetryPolicy`를 프레임워크의 핵심 전부처럼 설명했습니다. `3.x`에서는 톤을 조금 바꾸는 편이 맞습니다.
-
-이 타입들은 여전히 중요합니다.
-
-- `RequestInterceptor`
-- `ResponseInterceptor`
-- `RetryPolicy`
-
-하지만 프레임워크의 진짜 중심은 "인터셉터를 몇 개 붙일 수 있다"가 아니라, **request execution이 명시적인 정책 경계 안에서 실행된다**는 데 있습니다.
-
-README와 changelog를 보면 request/response execution은 internal transport policy와 explicit decoding strategy 쪽으로 재정리되어 있습니다. 이 레이어는 구현의 핵심이지만, 블로그에서는 **public contract가 아닌 운영 모델 설명** 정도로만 다루는 편이 정확합니다.
-
-## Download Lifecycle
-
-다운로드는 `InnoNetworkDownload` product가 담당합니다.
-
-```swift
-import Foundation
-import InnoNetworkDownload
-
-let manager = DownloadManager.shared
-let task = await manager.download(
-    url: URL(string: "https://example.com/file.zip")!,
-    toDirectory: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-)
-
-for await event in await manager.events(for: task) {
-    print(event)
-}
-```
-
-이 모듈의 핵심은 단순 파일 다운로드가 아닙니다.
-
-- foreground / background orchestration
-- pause / resume / retry
-- listener retention
-- append-log persistence 기반 durability
-
-즉, 다운로드를 "URLSession downloadTask 래퍼"가 아니라 **지속성과 이벤트 전달이 있는 lifecycle manager**로 보는 편이 맞습니다.
-
-필요하면 configuration도 명시적으로 생성할 수 있습니다.
-
-```swift
-let configuration = DownloadConfiguration.advanced { builder in
-    builder.maxConnectionsPerHost = 3
-    builder.maxRetryCount = 2
-}
-```
-
-새 코드에서는 `safeDefaults()`가 기본, `advanced`가 조정 경로라는 패턴이 여기서도 반복됩니다.
-
-## WebSocket Lifecycle
-
-웹소켓은 `InnoNetworkWebSocket`이 맡습니다.
-
-```swift
-import Foundation
-import InnoNetworkWebSocket
-
-let task = await WebSocketManager.shared.connect(
-    url: URL(string: "wss://echo.example.com/socket")!
-)
-
-for await event in await WebSocketManager.shared.events(for: task) {
-    print(event)
-}
-```
-
-이 product의 핵심은 단순 connect/send/receive API보다 아래 운영 모델입니다.
-
-- reconnect policy
-- handshake-aware close taxonomy
-- reconnect suppression rules
-- heartbeat / pong timeout
-- event delivery policy
-
-그래서 `WebSocketManager`를 설명할 때는 "실시간 통신을 지원한다"보다 **연결 실패와 재연결을 어떤 규칙으로 관리하는지**가 더 중요합니다.
-
-## Error Handling
-
-`InnoNetwork`는 opaque error보다 명시적인 transport error를 선호합니다.
-
-```swift
-do {
-    let user = try await client.request(GetUser())
-    print(user)
-} catch let error as NetworkError {
-    switch error {
-    case .invalidBaseURL(let url):
-        print("Invalid base URL: \(url)")
-    case .invalidRequestConfiguration(let message):
-        print("Invalid request configuration: \(message)")
-    case .statusCode(let response):
-        print("Unexpected status code: \(response.statusCode)")
-    case .objectMapping(let underlying, _):
-        print("Decoding failed: \(underlying)")
-    case .trustEvaluationFailed(let reason):
-        print("Trust evaluation failed: \(reason)")
-    case .cancelled:
-        print("Request cancelled")
-    default:
-        print(error)
+enum RemoteClientFactory {
+    static func makeClient(
+        baseURL: URL,
+        session: URLSessionProtocol = URLSession.shared
+    ) -> any NetworkClient {
+        let configuration = NetworkConfiguration.advanced(
+            baseURL: baseURL,
+            resilience: ResiliencePack(
+                retry: ExponentialBackoffRetryPolicy(
+                    maxRetries: 2,
+                    maxTotalRetries: 2,
+                    retryDelay: 0.4
+                )
+            ),
+            auth: AuthPack(
+                additionalSigners: [
+                    RemoteMetadataInterceptor(environment: .init(baseURL: baseURL)),
+                ],
+                additionalResponseInterceptors: [
+                    RemoteStatusInterceptor(),
+                ]
+            ),
+            transport: TransportPack(
+                timeout: 20.0,
+                cachePolicy: .reloadIgnoringLocalCacheData
+            )
+        )
+        return DefaultNetworkClient(configuration: configuration, session: session)
     }
 }
 ```
 
-특히 `invalidRequestConfiguration`은 단순 "뭔가 실패했다"가 아니라, request shape와 policy가 맞지 않는다는 신호에 가깝습니다. 예를 들어 query 인코딩 규칙이나 multipart payload shape가 잘못됐을 때 이런 에러가 나올 수 있습니다.
+여기서 retry, metadata, status handling, timeout이 한곳에 모입니다. 이 배치는 feature code를 깨끗하게 만들 뿐 아니라 운영 정책 리뷰를 쉽게 합니다.
 
-## Protocol Buffers는 이제 별도 패키지
+## Best practice 3. endpoint는 의미 있는 타입으로 둡니다
 
-이전 글에서는 protobuf 지원을 본 패키지의 확장 기능처럼 다뤘지만, `3.0.1` 기준으로는 **`InnoNetworkProtobuf`가 별도 패키지**입니다.
+반복적인 단순 API는 `EndpointBuilder`가 좋은 시작점입니다. 하지만 sample이나 production app에서 endpoint의 의미가 중요해지면 `APIDefinition` 타입으로 빼는 편이 좋습니다.
 
 ```swift
-dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", from: "3.0.1"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetworkProtobuf.git", branch: "main")
-]
+import InnoNetwork
+
+protocol RemoteRequest: APIDefinition {
+    var featureName: String { get }
+}
+
+extension RemoteRequest {
+    var method: HTTPMethod { .get }
+
+    var headers: HTTPHeaders {
+        var headers = HTTPHeaders.default
+        headers.update(name: "X-Sample-Feature", value: featureName)
+        return headers
+    }
+
+    var logger: NetworkLogger {
+        RemoteRequestLogger()
+    }
+}
 ```
 
-즉, protobuf가 필요한 앱은 `InnoNetwork`만 추가하면 끝이 아닙니다. 이 분리는 "기능이 사라졌다"기보다, core transport 패키지와 protobuf adapter layer를 더 명확히 분리한 것으로 보는 편이 맞습니다.
+이렇게 하면 공통 header와 logger 정책을 remote request 계층에 모을 수 있습니다. endpoint 호출부는 문자열 path 조합보다 훨씬 명확해집니다.
 
-## 언제 무엇을 써야 하나
+## Best practice 4. error를 remote failure로 한 번 변환합니다
 
-| 상황 | 권장 선택 |
-|------|-----------|
-| 일반적인 REST/HTTP API 요청 | `InnoNetwork` + `NetworkConfiguration.safeDefaults(baseURL:)` |
-| retry / trust / metrics 같은 운영 정책 조정 필요 | `NetworkConfiguration.advanced(baseURL:_:)` |
-| 파일 다운로드, 앱 생명주기와 연결된 progress 추적 | `InnoNetworkDownload` + `DownloadManager` |
-| reconnect와 heartbeat가 중요한 실시간 연결 | `InnoNetworkWebSocket` + `WebSocketManager` |
-| protobuf request/response 모델 필요 | `InnoNetwork` + `InnoNetworkProtobuf` |
+`NetworkError`를 feature까지 그대로 올리면 UI가 transport detail을 알게 됩니다. 반대로 모든 error를 `Error`로 뭉개면 원인을 잃습니다.
 
-## 마무리
+좋은 방식은 `Remote`에서 네트워크 error를 `RemoteFailure`로 변환하고, `Data/Domain`으로 올라가며 더 앱다운 error로 바꾸는 것입니다.
 
-`InnoNetwork 3.0.1`을 한 문장으로 정리하면, "타입 안전 HTTP 클라이언트"보다는 **운영 정책이 명시된 네트워크 프레임워크 제품군**이 더 정확한 설명입니다.
+이렇게 나누면 각 레이어의 책임이 선명해집니다.
 
-`APIDefinition`과 `DefaultNetworkClient`는 여전히 출발점입니다. 하지만 실제로 `3.x`를 잘 쓰려면 다음 네 가지를 같이 이해해야 합니다.
+- InnoNetwork: HTTP/transport/decoding error classification
+- Remote: 외부 API 호출 실패 의미로 변환
+- Data: repository policy 적용
+- Domain: feature가 이해할 수 있는 domain error 제공
 
-- `safeDefaults`가 기본 경로라는 점
-- `advanced`는 운영 정책이 필요할 때만 쓴다는 점
-- download / websocket lifecycle이 별도 product라는 점
-- protobuf가 별도 패키지로 분리되었다는 점
+feature는 "timeout인지, 500인지, decoding 실패인지"를 필요할 때만 domain language로 받습니다.
 
-더 자세히 보려면 아래 문서부터 읽는 걸 추천합니다.
+## Best practice 5. 테스트는 URLSession 경계에서 끊습니다
 
-1. [README](https://github.com/InnoSquadCorp/InnoNetwork)
-2. [`API_STABILITY.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/API_STABILITY.md)
-3. [`Examples/README.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/Examples/README.md)
-4. [`docs/releases/3.0.1.md`](https://github.com/InnoSquadCorp/InnoNetwork/blob/main/docs/releases/3.0.1.md)
+InnoNetwork는 `URLSessionProtocol`과 test support를 통해 네트워크 경계를 테스트하기 좋게 만듭니다. InnoSample의 remote test는 stub session으로 실제 request header와 response mapping을 확인합니다.
+
+검증해야 할 것은 "진짜 인터넷이 되는가"가 아닙니다.
+
+- path가 맞는가
+- header가 붙는가
+- status error가 변환되는가
+- decoding failure가 올바르게 분류되는가
+- retry/interceptor ordering이 의도와 맞는가
+
+이런 테스트는 feature UI test보다 빠르고 안정적입니다.
+
+## 도입했을 때 얻는 장점
+
+InnoNetwork를 잘 쓰면 다음 장점이 생깁니다.
+
+- endpoint 계약이 타입으로 남습니다.
+- retry/auth/interceptor 정책이 호출부 밖으로 빠집니다.
+- 네트워크 error가 더 일관되게 분류됩니다.
+- feature가 transport 구현을 모릅니다.
+- remote layer test가 쉬워집니다.
+- download/websocket/cache/trust 같은 운영 기능을 같은 철학으로 확장할 수 있습니다.
+
+단순히 "HTTP 호출을 쉽게 한다"가 핵심이 아닙니다. **네트워크가 앱 아키텍처를 침범하지 못하게 막는 것**이 더 큰 가치입니다.
+
+## 언제 쓰면 좋은가
+
+InnoNetwork는 이런 상황에서 매력이 큽니다.
+
+- endpoint가 많고 공통 정책이 필요한 앱
+- auth refresh, retry, timeout, logging이 중요한 앱
+- feature별 네트워크 코드 중복이 늘어난 앱
+- Swift Concurrency와 strict error classification을 선호하는 팀
+- download, websocket, persistent cache까지 같은 package family로 다루고 싶은 팀
+
+반대로 일회성 script나 아주 작은 prototype에서는 URLSession만으로 충분할 수 있습니다.
+
+## InnoSample에서의 결론
+
+[`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice %})에서 InnoNetwork는 `Remote` 안에만 강하게 존재합니다.
+
+- `RemoteContainer`가 `NetworkClient`와 remote data source를 조립합니다.
+- `RemoteClientFactory`가 retry/interceptor/timeout/logger 정책을 만듭니다.
+- `RemoteRequest`가 공통 request surface를 제공합니다.
+- `Data`는 remote data source protocol만 압니다.
+- `Domain`과 `Feature`는 InnoNetwork를 모릅니다.
+
+이것이 InnoNetwork의 좋은 사용법입니다. **네트워크 실행 정책은 강하게 타입화하되, 앱 바깥 경계에 가둡니다.** 그러면 feature는 더 단순해지고, 네트워크 정책은 더 운영 가능한 형태로 남습니다.

--- a/_posts/2026-02-23-innorouter-swiftui-navigation-en.md
+++ b/_posts/2026-02-23-innorouter-swiftui-navigation-en.md
@@ -1,526 +1,201 @@
 ---
-title: "InnoRouter: A type-safe navigation framework for SwiftUI"
+title: "InnoRouter Best Practices: Managing SwiftUI Navigation with Routes and Coordinators"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innorouter-swiftui-navigation
 lang: en
+description: "Why InnoRouter is useful, how to replace view-local path mutation with route, store, and coordinator boundaries, and how InnoSample applies that pattern."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, navigation, swiftui, coordinator, clean-architecture, unidirectional]
+tags: [swift, iOS, navigation, swiftui, coordinator, deep-link, architecture, route]
 author: ethan
 toc: true
 comments: true
 ---
 
-## Why revisit it now?
+## Why SwiftUI navigation gets hard in real apps
 
-`NavigationStack` made SwiftUI navigation much cleaner, but real apps still run into the same problems.
+SwiftUI's navigation APIs are enough for small flows. In larger apps, navigation becomes an architecture problem.
 
-- path state gets scattered across screens and features
-- authentication, deep links, logging, and policy checks leak into view code
-- "the user moved from A to B" is hard to model as testable data
+- Route path state scatters across views.
+- Deep links mix with screen code.
+- Modal, push, and tab movement are handled differently.
+- Cross-feature navigation creates direct imports.
+- Navigation tests require booting UI.
 
-`InnoRouter` 3.0 approaches this as a typed navigation runtime, not as a set of push/pop helpers. The important part is the boundary: `RouteStack` for state, `NavigationCommand` for execution, and SwiftUI-facing hosts and stores that keep mutation authority in one place.
+[`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter) treats navigation as typed state and explicit command execution, not view-local side effects. Its strongest appeal is that **screen movement becomes data, and coordinators execute that data.**
 
-This post reframes InnoRouter around the runtime surface that exists in the codebase today.
+## The boundary InnoRouter should own
 
----
+InnoRouter should own:
 
-## What InnoRouter actually owns
+- route stack state
+- navigation command execution
+- modal presentation authority
+- tab coordinator state
+- deep-link matching and planning
+- navigation effect adapters
+- host-less navigation tests
 
-According to the current README, InnoRouter owns five areas.
+It should not own:
 
-| Area | Core types | Responsibility |
-|---|---|---|
-| Stack state | `RouteStack`, `RouteStackValidator` | current navigation snapshot and validation rules |
-| Command execution | `NavigationCommand`, `NavigationEngine`, `NavigationResult` | typed push/pop/replace execution |
-| SwiftUI authority | `NavigationStore`, `NavigationHost`, `@EnvironmentNavigationIntent` | stack routing authority for views |
-| Modal authority | `ModalStore`, `ModalHost`, `ModalIntent` | `sheet` and `fullScreenCover` routing |
-| Deep-link planning | `DeepLinkMatcher`, `DeepLinkPipeline`, `PendingDeepLink`, `NavigationPlan` | URL matching and explicit execution planning |
-
-Just as important: InnoRouter does not try to become your whole application state machine.
-
-Keep these concerns outside it:
-
-- authentication and session lifecycle
 - business workflow state
-- networking retry or transport state
-- feature-local presentation like `alert` and `confirmationDialog`
+- network retry or session lifecycle
+- dependency graph construction
+- feature-local alerts and confirmation dialogs
+- authentication domain policy itself
 
----
+InnoRouter answers "which screen should this feature show, and how?" The reason to move comes from feature logic; the UI renders the route.
 
-## The runtime model
-
-At the center of InnoRouter are `RouteStack` and `NavigationCommand`.
-
-### 1. `RouteStack`
-
-`RouteStack` is the value-type snapshot of your current stack navigation state.
-
-```swift
-import InnoRouter
-
-let stack = try RouteStack<HomeRoute>(
-    validating: [.list, .detail(id: "123")],
-    using: .nonEmpty.combined(with: .rooted(at: .list))
-)
-```
-
-`RouteStackValidator` lets you pull app invariants closer to the state model.
-
-- should empty stacks be allowed?
-- must the stack start from a specific root?
-- should duplicate routes be rejected?
-
-### 2. `NavigationCommand`
-
-Navigation changes are expressed as commands.
-
-- `.push(route)`
-- `.pop`
-- `.popCount(n)`
-- `.popTo(route)`
-- `.popToRoot`
-- `.replace([route])`
-- `.sequence([...])`
-
-That changes the discussion from "which screen did we end up on?" to "which command did we execute?" which is much easier to test and log.
-
-### 3. `NavigationEngine` and result types
-
-Execution returns `NavigationResult`, so failures and cancellations are part of the public surface instead of hidden side effects.
-
-InnoRouter distinguishes three execution semantics.
-
-| Mode | Best use case |
-|---|---|
-| Single command | one normal push/pop |
-| Batch | sequential commands with aggregated observation |
-| Transaction | all-or-nothing commits with rollback semantics |
-
-`.sequence` is not a transaction. It runs left-to-right, and earlier successful steps remain applied even if a later step fails.
-
----
-
-## The SwiftUI entry point
-
-The most important SwiftUI type is `NavigationStore`.
-
-### `NavigationStore` is shared authority
-
-`NavigationStore` is not just a convenience wrapper. It is the stack-routing authority.
-
-- it owns the current `RouteStack`
-- it applies middleware
-- it reconciles `NavigationStack(path:)`
-- it converts `NavigationIntent` into semantic command execution
-
-The baseline example should now match `Examples/StandaloneExample.swift`.
-
-```swift
-import SwiftUI
-import InnoRouter
-import InnoRouterMacros
-
-@Routable
-enum HomeRoute {
-    case list
-    case detail(id: String)
-    case settings
-}
-
-struct AppRoot: View {
-    @State private var store = try! NavigationStore<HomeRoute>(
-        initialPath: [.list],
-        configuration: NavigationStoreConfiguration(
-            routeStackValidator: .nonEmpty.combined(with: .rooted(at: .list))
-        )
-    )
-
-    var body: some View {
-        NavigationHost(store: store) { route in
-            switch route {
-            case .list:
-                HomeListView()
-            case .detail(let id):
-                DetailView(id: id)
-            case .settings:
-                SettingsView()
-            }
-        } root: {
-            HomeListView()
-        }
-    }
-}
-```
-
-### Views emit intent instead of mutating state
-
-Views should send intent through `@EnvironmentNavigationIntent`.
-
-```swift
-struct HomeListView: View {
-    @EnvironmentNavigationIntent(HomeRoute.self) private var navigationIntent
-
-    var body: some View {
-        List {
-            Button("Detail") {
-                navigationIntent.send(.go(.detail(id: "123")))
-            }
-
-            Button("Settings") {
-                navigationIntent.send(.go(.settings))
-            }
-
-            Button("Back") {
-                navigationIntent.send(.back)
-            }
-        }
-    }
-}
-```
-
-The current stack intent surface is:
-
-```swift
-public enum NavigationIntent<R: Route>: Sendable, Equatable {
-    case go(R)
-    case goMany([R])
-    case back
-    case backBy(Int)
-    case backTo(R)
-    case backToRoot
-    case resetTo([R])
-}
-```
-
-Older descriptions sometimes showed `deepLink(URL)` as part of `NavigationIntent`. That is no longer the model. Deep links live in a separate planning layer.
-
----
-
-## Coordinators are policy objects
-
-`Coordinator` is the layer between SwiftUI intent and command execution when routing policy needs to intervene.
-
-```swift
-@Observable
-@MainActor
-final class AppCoordinator: Coordinator {
-    typealias RouteType = AppRoute
-    typealias Destination = AppDestinationView
-
-    let store = NavigationStore<AppRoute>()
-    var isAuthenticated = false
-
-    func handle(_ intent: NavigationIntent<AppRoute>) {
-        switch intent {
-        case .go(.settings) where !isAuthenticated:
-            _ = store.execute(.replace([.login]))
-        default:
-            store.send(intent)
-        }
-    }
-
-    @ViewBuilder
-    func destination(for route: AppRoute) -> AppDestinationView {
-        AppDestinationView(route: route)
-    }
-}
-```
-
-Use this layer when:
-
-- routing needs authentication or app policy checks first
-- an app shell composes multiple navigation authorities
-- view code should not know about routing policy
-
-You connect it through `CoordinatorHost` or `CoordinatorSplitHost`.
-
-```swift
-struct RootView: View {
-    @State private var coordinator = AppCoordinator()
-
-    var body: some View {
-        CoordinatorHost(coordinator: coordinator) {
-            ContentView()
-        }
-    }
-}
-```
-
-`FlowCoordinator` and `TabCoordinator` are also part of the public surface, but they complement `NavigationStore`; they do not replace it.
-
----
-
-## Modal routing is a separate surface
-
-One of the biggest runtime clarifications in InnoRouter 3.0 is that modal routing is not mixed into stack routing.
-
-`sheet` and `fullScreenCover` live behind `ModalStore` and `ModalHost`.
-
-```swift
-@Routable
-enum AppModalRoute {
-    case profile
-    case onboarding
-}
-
-struct ShellView: View {
-    @State private var modalStore = ModalStore<AppModalRoute>()
-
-    var body: some View {
-        ModalHost(store: modalStore) { route in
-            switch route {
-            case .profile:
-                ProfileView()
-            case .onboarding:
-                OnboardingView()
-            }
-        } content: {
-            HomeView()
-        }
-    }
-}
-```
-
-Views send presentation intent through `@EnvironmentModalIntent`.
-
-```swift
-struct HomeView: View {
-    @EnvironmentModalIntent(AppModalRoute.self) private var modalIntent
-
-    var body: some View {
-        VStack {
-            Button("Profile") {
-                modalIntent.send(.present(.profile, style: .sheet))
-            }
-
-            Button("Dismiss") {
-                modalIntent.send(.dismiss)
-            }
-        }
-    }
-}
-```
-
-This separation matters because:
-
-- stack path and modal queue stay independent
-- modal lifecycle can be observed explicitly
-- modal routing intentionally does not expose middleware the way stack routing does
-
----
-
-## Deep links are plans, not hidden side effects
-
-Deep-link handling is one of the clearest examples of the runtime shift in 3.0.
-
-1. `DeepLinkMatcher` maps a URL to a route
-2. `DeepLinkPipeline` applies scheme, host, and authentication policy
-3. the result becomes `.plan`, `.pending`, `.rejected`, or `.unhandled`
-4. the app explicitly decides when to execute the resulting plan
-
-### Matcher
-
-```swift
-let matcher = DeepLinkMatcher<ProductRoute> {
-    DeepLinkMapping("/products") { _ in .list }
-    DeepLinkMapping("/products/:id") { params in
-        params.firstValue(forName: "id").map { .detail(id: $0) }
-    }
-}
-```
-
-`DeepLinkMatcher` can also surface structural diagnostics:
-
-- duplicate patterns
-- wildcard shadowing
-- parameter shadowing
-
-That helps catch authoring mistakes without changing declaration-order precedence.
-
-### Pipeline
-
-```swift
-let pipeline = DeepLinkPipeline<ProductRoute>(
-    allowedSchemes: ["myapp", "https"],
-    allowedHosts: ["myapp.com"],
-    resolve: { matcher.match($0) },
-    authenticationPolicy: .required(
-        shouldRequireAuthentication: { route in
-            if case .detail = route { return true }
-            return false
-        },
-        isAuthenticated: { authManager.isLoggedIn }
-    ),
-    plan: { route in NavigationPlan(commands: [.push(route)]) }
-)
-```
-
-The important change is this: URLs do not immediately mutate navigation state.
-
-- `.plan` means "safe to execute now"
-- `.pending` means "hold until auth succeeds"
-- `.rejected` means scheme/host policy blocked it
-- `.unhandled` means no mapping resolved the URL
-
-A typical SwiftUI integration looks like this:
-
-```swift
-.onOpenURL { url in
-    switch pipeline.decide(for: url) {
-    case .plan(let plan):
-        _ = store.executeBatch(plan.commands)
-
-    case .pending(let pending):
-        self.pendingDeepLink = pending
-
-    case .rejected(let reason):
-        logger.error("Rejected deep link: \(String(describing: reason))")
-
-    case .unhandled(let url):
-        logger.error("Unhandled deep link: \(url.absoluteString)")
-    }
-}
-```
-
-That makes "resume after login" a first-class model through `PendingDeepLink`, not an ad hoc branch scattered across the app.
-
----
-
-## Middleware is the cross-cutting policy layer
-
-InnoRouter middleware is more than a callback hook. It sits on the command boundary.
-
-### What it can do
-
-- rewrite commands before execution
-- block execution with typed cancellation
-- observe and fold results after execution
-
-### What it cannot do
-
-- mutate store state directly
-
-For example, this blocks duplicate pushes.
-
-```swift
-store.addMiddleware(
-    AnyNavigationMiddleware(
-        willExecute: { command, state in
-            if case .push(let next) = command, state.path.last == next {
-                return .cancel(.conditionFailed)
-            }
-            return .proceed(command)
-        }
-    ),
-    debugName: "PreventDuplicatePush"
-)
-```
-
-That is the right place for auth checks, analytics, and preconditions. Views remain focused on intent, not policy.
-
----
-
-## Use effect modules at the app boundary
-
-If app-shell or coordinator code wants an explicit execution facade instead of talking to a store directly, InnoRouter ships effect modules for that boundary.
-
-### `InnoRouterNavigationEffects`
-
-This module wraps navigation execution in a small synchronous `@MainActor` API.
-
-- `execute(_:)`
-- `execute(_ commands:)`
-- `executeTransaction(_:)`
-- `executeGuarded(_:, prepare:)`
-
-That keeps app-boundary code focused on execution decisions instead of store internals.
-
-### `InnoRouterDeepLinkEffects`
-
-This module combines deep-link planning with execution helpers.
-
-- execute a deep-link plan
-- receive typed effect outcomes
-- resume pending deep links after authentication
-
-It is the boundary where deep-link planning turns into app policy and actual execution.
-
----
-
-## Macros are now the preferred public style
-
-Current public examples use `@Routable` as the default style instead of hand-written `Route` conformance.
-
-```swift
-import InnoRouter
-import InnoRouterMacros
-
-@Routable
-enum HomeRoute {
-    case list
-    case detail(id: String)
-    case settings
-}
-```
-
-`@Routable` removes the manual `Route` conformance declaration for route enums.
-
-`@CasePathable` is the companion macro when you want lightweight case-path extraction and composition for enum hierarchies. It is not required in every example, but it belongs in the current public API story.
-
----
-
-## Which surface should you use?
-
-| Situation | Recommended surface |
-|---|---|
-| single stack-based app | `NavigationStore` + `NavigationHost` |
-| policy must run before navigation | `CoordinatorHost` + `Coordinator.handle(_:)` |
-| iPad/macOS detail stack | `NavigationSplitHost` or `CoordinatorSplitHost` |
-| `sheet` / `fullScreenCover` routing | `ModalStore` + `ModalHost` |
-| URL entry and auth resumption | `DeepLinkMatcher` + `DeepLinkPipeline` |
-| explicit boundary execution facade | `InnoRouterNavigationEffects`, `InnoRouterDeepLinkEffects` |
-
-That table captures the design intent well: InnoRouter is not about pushing everything into one giant coordinator. It is about separating navigation state, policy, modal routing, and deep-link execution into typed boundaries.
-
----
-
-## Installation and requirements
+## Installation and imports
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", from: "3.0.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", from: "4.2.1")
 ]
 ```
 
-Current requirements:
+Most app code imports the umbrella product. Files using route macros import `InnoRouterMacros` explicitly.
 
-- iOS 18+
-- macOS 15+
-- tvOS 18+
-- watchOS 11+
-- Swift 6.2+
+```swift
+import InnoRouter
+import InnoRouterMacros
 
-The runtime surface assumes Swift 6.2 and strict concurrency, which is reflected in `Sendable`, `@MainActor`, and typed result modeling across the package.
+@Routable
+enum PeopleRoute {
+    case detail(UserSummary)
+}
+```
 
----
+Keeping macro imports local means non-macro files do not pay unnecessary macro-plugin resolution cost.
 
-## Closing thoughts
+## Best practice 1. Do not let views own path mutation
 
-The shortest accurate description of InnoRouter today is this:
+When SwiftUI views directly own `NavigationPath`, push and pop logic spreads through the view tree.
 
-> InnoRouter is not just a SwiftUI navigation abstraction. It is a typed navigation runtime that organizes app boundaries around route state and command execution.
+InnoRouter pushes the ownership outward:
 
-That pays off in a few concrete ways.
+- routes are declared as enums
+- stores own route stacks
+- hosts connect those stores to SwiftUI
+- coordinators translate user intent into navigation commands
 
-1. navigation state becomes explicit through `RouteStack`
-2. command, batch, and transaction semantics stay visible and testable
-3. stack, modal, and deep-link authority remain separate
-4. policy moves out of views and into coordinators, middleware, and effect boundaries
+```swift
+final class PeopleFeatureCoordinator {
+    let navigationStore = NavigationStore<PeopleRoute>()
+    let modalStore = ModalStore<PeopleModalRoute>()
 
-If navigation keeps spreading through your SwiftUI codebase as view-local behavior, InnoRouter gives you a stronger model: treat it as state, commands, and explicit execution boundaries.
+    func showDetail(user: UserSummary) {
+        navigationStore.send(.go(.detail(user)))
+    }
+}
+```
 
-## References
+Views render routes through `NavigationHost` or `ModalHost`. Push and pop become feature-boundary state, not local view state.
 
-- [InnoRouter GitHub Repository](https://github.com/InnoSquadCorp/InnoRouter)
-- [Latest InnoRouter DocC](https://innosquadcorp.github.io/InnoRouter/latest/)
-- [SwiftUI NavigationStack](https://developer.apple.com/documentation/swiftui/navigationstack)
+## Best practice 2. Leaf features should know only their own navigation
+
+If one feature imports another feature's router directly, dependency cycles appear quickly. InnoSample solves this by mediating at the parent coordinator.
+
+`PeopleFeature` does not push settings directly. Its reducer emits `pendingSettingsRequest`; `PeopleFeatureCoordinator` exposes a way to consume that request. The root `EntireTabCoordinator` performs the tab switch and asks `SettingsFeatureCoordinator` to show the detail.
+
+```swift
+@MainActor
+@Observable
+public final class EntireTabCoordinator: TabCoordinator {
+    let peopleCoordinator: PeopleFeatureCoordinator
+    let postsCoordinator: PostsFeatureCoordinator
+    let settingsCoordinator: SettingsFeatureCoordinator
+
+    func syncCrossFeatureNavigationFromPeople() {
+        guard let request = peopleCoordinator.consumeSettingsRequest() else { return }
+        selectedTab = .settings
+        settingsCoordinator.showDetail(assigneeID: request.assigneeID)
+    }
+
+    func syncCrossFeatureNavigationFromSettings() {
+        guard let request = settingsCoordinator.consumePeopleRequest() else { return }
+        selectedTab = .people
+        peopleCoordinator.showDetail(userID: request.userID)
+    }
+}
+```
+
+The key is separating runtime movement from compile-time dependency.
+
+- Runtime: `People -> Settings -> People` movement is allowed.
+- Compile time: `People -> EntireTab <- Settings` stays intact.
+
+That is one of the strongest reasons to use InnoRouter in a multi-feature SwiftUI app.
+
+## Best practice 3. Separate navigation intent from business state
+
+Navigation can be the result of business logic, but the route stack itself is not business state.
+
+A good flow is:
+
+1. An InnoFlow reducer emits intent.
+2. A feature coordinator consumes the intent.
+3. The coordinator sends a route command to an InnoRouter store.
+4. A SwiftUI host renders the route.
+
+That split lets reducer tests run without a navigation framework and router tests run without domain use cases.
+
+## Best practice 4. Use one language for modal, tab, and stack navigation
+
+SwiftUI apps often scatter push, modal, and tab handling across `NavigationStack`, `.sheet`, and `TabView`. InnoRouter lets you describe them with the same route/coordinator mindset.
+
+- `NavigationStore`: push stacks
+- `ModalStore`: sheet and full-screen cover authority
+- `TabCoordinator`: selected tab, content, and badge state
+- `DeepLinkPipeline`: app-boundary URL planning
+
+The products are split, but the idea is the same: navigation is data, and hosts execute it.
+
+## Best practice 5. Plan deep links at the app boundary
+
+Parsing deep links inside feature views scatters app-level route policy. InnoRouter's deep-link surface moves matching and planning to the app boundary.
+
+In production, a good default is:
+
+- parse URLs and plan routes at the root coordinator or app boundary
+- pass only feature-level route intent into leaf features
+- keep auth/session gating in app policy
+- store and resume pending deep links explicitly
+
+This becomes more valuable as the number of deep links grows.
+
+## What you gain by adopting it
+
+Used well, InnoRouter gives you:
+
+- route definitions as typed data
+- views that do not directly mutate path state
+- host-less navigation tests
+- fewer compile-time cycles between sibling features
+- one mental model for modal, tab, push, and deep link flows
+- a coordinator boundary for navigation side effects
+
+In apps with many features, tabs, modals, and deep links, navigation becomes an explicit model instead of a side effect of view implementation.
+
+## When it is a good fit
+
+InnoRouter is a good fit for:
+
+- SwiftUI apps with navigation spread across multiple features
+- apps that combine tabs, modals, pushes, and deep links
+- teams trying to reduce direct feature-to-feature imports
+- teams that want navigation tests
+- teams that prefer strict concurrency and typed route models
+
+For a tiny app with only a few screens, SwiftUI's native navigation APIs may be enough.
+
+## How InnoSample uses it
+
+In [`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice-en %}), InnoRouter lives in `Router` targets.
+
+- `PeopleFeatureRouter` knows only People navigation.
+- `PostsFeatureRouter` knows only Posts navigation.
+- `SettingsFeatureRouter` knows only Settings navigation.
+- `EntireTabCoordinator` mediates sibling movement.
+- `FeatureContainer` wires leaf coordinators together.
+
+That is the best way to use InnoRouter: **leaf features own their own routes, and cross-feature navigation belongs to a parent coordinator.** The app can move flexibly at runtime while compile-time dependencies stay clean.

--- a/_posts/2026-02-23-innorouter-swiftui-navigation.md
+++ b/_posts/2026-02-23-innorouter-swiftui-navigation.md
@@ -1,524 +1,201 @@
 ---
-title: "InnoRouter: SwiftUI를 위한 타입 안전 내비게이션 프레임워크"
+title: "InnoRouter Best Practice: SwiftUI Navigation을 Route와 Coordinator로 다루기"
 date: 2026-02-23 00:00:00 +0900
 translation_key: innorouter-swiftui-navigation
 lang: ko-KR
+description: "InnoRouter를 왜 써야 하는지, SwiftUI navigation을 view-local path 조작 대신 route, store, coordinator 경계로 관리하는 best practice를 설명합니다."
 categories: [iOS, Swift, Architecture]
-tags: [swift, iOS, navigation, swiftui, coordinator, clean-architecture, unidirectional]
+tags: [swift, iOS, navigation, swiftui, coordinator, deep-link, architecture, route]
 author: ethan
 toc: true
 comments: true
 ---
 
-## 왜 다시 봐야 할까요?
+## 왜 SwiftUI navigation이 실무에서 어려운가
 
-처음 `NavigationStack`를 도입했을 때 SwiftUI 내비게이션은 분명 좋아졌습니다. 하지만 앱이 커지면 문제는 다시 생깁니다.
+SwiftUI의 navigation API는 작은 화면 흐름에서는 충분합니다. 하지만 앱이 커지면 navigation은 단순한 화면 전환이 아니라 app architecture 문제가 됩니다.
 
-- path 상태가 여러 화면과 feature에 흩어집니다.
-- 인증, 딥링크, 로깅, 정책 판단이 화면 코드에 섞입니다.
-- "A에서 B로 간다"는 흐름을 테스트 가능한 데이터로 다루기 어렵습니다.
+- route path가 여러 view에 흩어집니다.
+- deep link가 화면 코드와 섞입니다.
+- modal, push, tab 전환이 서로 다른 방식으로 관리됩니다.
+- feature 간 이동이 직접 import로 연결됩니다.
+- navigation을 테스트하려면 실제 UI를 띄워야 합니다.
 
-`InnoRouter` 3.0은 이 문제를 "내비게이션을 위한 typed runtime"으로 풀어냅니다. 핵심은 단순히 push/pop helper를 제공하는 것이 아니라, `RouteStack` 상태와 `NavigationCommand` 실행을 중심으로 SwiftUI 경계를 명확하게 나누는 데 있습니다.
+[`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter)는 navigation을 view-local side effect가 아니라 typed state와 command로 다루게 합니다. 핵심 매력은 **화면 이동을 데이터화하고, coordinator가 그 데이터를 실행하게 만드는 것**입니다.
 
-이 글은 예전 "Intent 기반 내비게이션 프레임워크" 설명을 넘어, 현재 코드베이스가 실제로 제공하는 런타임 surface를 기준으로 InnoRouter를 다시 정리합니다.
+## InnoRouter가 소유하는 경계
 
----
+InnoRouter가 소유하기 좋은 것:
 
-## InnoRouter가 실제로 소유하는 것
+- route stack state
+- navigation command execution
+- modal presentation authority
+- tab coordinator state
+- deep-link matching and planning
+- navigation effect adapter
+- host-less navigation test
 
-README 기준으로 InnoRouter는 아래 다섯 축을 소유합니다.
+소유하지 말아야 하는 것:
 
-| 축 | 핵심 타입 | 설명 |
-|---|---|---|
-| Stack state | `RouteStack`, `RouteStackValidator` | 현재 내비게이션 스냅샷과 검증 규칙 |
-| Command execution | `NavigationCommand`, `NavigationEngine`, `NavigationResult` | push/pop/replace를 typed command로 실행 |
-| SwiftUI authority | `NavigationStore`, `NavigationHost`, `@EnvironmentNavigationIntent` | 뷰가 상태를 직접 바꾸지 않고 intent를 보내도록 만드는 계층 |
-| Modal authority | `ModalStore`, `ModalHost`, `ModalIntent` | `sheet`, `fullScreenCover`를 별도 surface로 분리 |
-| Deep-link planning | `DeepLinkMatcher`, `DeepLinkPipeline`, `PendingDeepLink`, `NavigationPlan` | URL을 즉시 실행하지 않고 계획으로 다루는 모델 |
+- business workflow state
+- network retry/session lifecycle
+- DI graph construction
+- feature-local alert/confirmation dialog
+- authentication domain policy 자체
 
-중요한 점은 InnoRouter가 앱의 모든 상태를 가져가지 않는다는 것입니다. 아래는 여전히 앱이 직접 소유해야 합니다.
+즉 InnoRouter는 "어떤 화면으로 어떻게 이동할 것인가"를 맡습니다. "왜 이동해야 하는가"는 feature logic이 intent로 표현하고, "무엇을 보여줄 것인가"는 UI가 맡는 편이 좋습니다.
 
-- 인증/세션 라이프사이클
-- 비즈니스 워크플로 상태
-- 네트워크 재시도나 transport 상태
-- `alert`, `confirmationDialog` 같은 feature-local presentation 상태
-
----
-
-## Runtime 모델
-
-InnoRouter의 중심에는 `RouteStack`과 `NavigationCommand`가 있습니다.
-
-### 1. `RouteStack`
-
-`RouteStack`은 현재 stack navigation 상태를 표현하는 값 타입입니다. 중요한 점은 "지금 화면이 어디인가"를 view-local side effect가 아니라 명시적인 스냅샷으로 다룬다는 것입니다.
-
-```swift
-import InnoRouter
-
-let stack = try RouteStack<HomeRoute>(
-    validating: [.list, .detail(id: "123")],
-    using: .nonEmpty.combined(with: .rooted(at: .list))
-)
-```
-
-`RouteStackValidator`를 붙이면 앱 규칙도 타입 근처로 끌어올릴 수 있습니다.
-
-- 빈 스택을 금지할지
-- 특정 루트에서만 시작하게 할지
-- 중복 route를 허용할지
-
-### 2. `NavigationCommand`
-
-내비게이션 변경은 전부 command로 표현됩니다.
-
-- `.push(route)`
-- `.pop`
-- `.popCount(n)`
-- `.popTo(route)`
-- `.popToRoot`
-- `.replace([route])`
-- `.sequence([...])`
-
-이렇게 하면 "어디로 갔는가"보다 "어떤 명령을 실행했는가"를 테스트하고 로깅할 수 있습니다.
-
-### 3. `NavigationEngine`과 결과 타입
-
-실행 결과는 `NavigationResult`로 돌아옵니다. 그래서 명령 실패나 취소도 암묵적으로 삼키지 않습니다.
-
-InnoRouter는 세 가지 실행 semantics를 구분합니다.
-
-| 방식 | 언제 쓰면 좋은가 |
-|---|---|
-| Single command | 일반적인 push/pop 한 번 |
-| Batch | 여러 command를 순차 실행하되 관찰은 한 번으로 묶고 싶을 때 |
-| Transaction | 하나라도 실패하면 전체 commit을 취소해야 할 때 |
-
-여기서 `.sequence`는 transaction이 아닙니다. 왼쪽부터 실행되고, 앞선 성공은 뒤 명령이 실패해도 유지됩니다.
-
----
-
-## SwiftUI 진입점
-
-SwiftUI에서 가장 중요한 타입은 `NavigationStore`입니다.
-
-### `NavigationStore`는 shared authority다
-
-`NavigationStore`는 단순한 convenience wrapper가 아니라 stack routing authority입니다.
-
-- 현재 `RouteStack` 보유
-- middleware 적용
-- `NavigationStack(path:)`와의 path reconciliation 처리
-- `NavigationIntent`를 실제 command 실행으로 변환
-
-기본 예제는 현재 `Examples/StandaloneExample.swift`와 거의 같습니다.
-
-```swift
-import SwiftUI
-import InnoRouter
-import InnoRouterMacros
-
-@Routable
-enum HomeRoute {
-    case list
-    case detail(id: String)
-    case settings
-}
-
-struct AppRoot: View {
-    @State private var store = try! NavigationStore<HomeRoute>(
-        initialPath: [.list],
-        configuration: NavigationStoreConfiguration(
-            routeStackValidator: .nonEmpty.combined(with: .rooted(at: .list))
-        )
-    )
-
-    var body: some View {
-        NavigationHost(store: store) { route in
-            switch route {
-            case .list:
-                HomeListView()
-            case .detail(let id):
-                DetailView(id: id)
-            case .settings:
-                SettingsView()
-            }
-        } root: {
-            HomeListView()
-        }
-    }
-}
-```
-
-### 뷰는 store를 직접 mutate하지 않는다
-
-뷰는 `@EnvironmentNavigationIntent`를 통해 intent만 보냅니다.
-
-```swift
-struct HomeListView: View {
-    @EnvironmentNavigationIntent(HomeRoute.self) private var navigationIntent
-
-    var body: some View {
-        List {
-            Button("Detail") {
-                navigationIntent.send(.go(.detail(id: "123")))
-            }
-
-            Button("Settings") {
-                navigationIntent.send(.go(.settings))
-            }
-
-            Button("Back") {
-                navigationIntent.send(.back)
-            }
-        }
-    }
-}
-```
-
-현재 stack intent surface는 아래 일곱 가지입니다.
-
-```swift
-public enum NavigationIntent<R: Route>: Sendable, Equatable {
-    case go(R)
-    case goMany([R])
-    case back
-    case backBy(Int)
-    case backTo(R)
-    case backToRoot
-    case resetTo([R])
-}
-```
-
-예전 설명에서 보이던 `deepLink(URL)` 같은 케이스는 현재 `NavigationIntent` surface에 없습니다. 딥링크는 stack intent가 아니라 별도의 planning 모델에서 다루는 것이 핵심 변화입니다.
-
----
-
-## Coordinator는 정책 계층입니다
-
-`Coordinator`는 또 다른 store가 아니라, SwiftUI intent와 실행 사이에 정책을 끼워 넣는 경계입니다.
-
-```swift
-@Observable
-@MainActor
-final class AppCoordinator: Coordinator {
-    typealias RouteType = AppRoute
-    typealias Destination = AppDestinationView
-
-    let store = NavigationStore<AppRoute>()
-    var isAuthenticated = false
-
-    func handle(_ intent: NavigationIntent<AppRoute>) {
-        switch intent {
-        case .go(.settings) where !isAuthenticated:
-            _ = store.execute(.replace([.login]))
-        default:
-            store.send(intent)
-        }
-    }
-
-    @ViewBuilder
-    func destination(for route: AppRoute) -> AppDestinationView {
-        AppDestinationView(route: route)
-    }
-}
-```
-
-이 레이어가 필요한 경우는 아래와 같습니다.
-
-- 인증 정책이 화면 이동 전에 개입해야 할 때
-- 앱 셸에서 여러 navigation authority를 조합해야 할 때
-- view 코드가 알 필요 없는 라우팅 규칙을 한 곳에 모으고 싶을 때
-
-실제 사용은 `CoordinatorHost` 또는 `CoordinatorSplitHost`로 연결합니다.
-
-```swift
-struct RootView: View {
-    @State private var coordinator = AppCoordinator()
-
-    var body: some View {
-        CoordinatorHost(coordinator: coordinator) {
-            ContentView()
-        }
-    }
-}
-```
-
-`FlowCoordinator`와 `TabCoordinator`도 있습니다. 다만 이것들은 `NavigationStore`를 대체하는 것이 아니라, step progression이나 탭 선택처럼 다른 종류의 UI 흐름을 보완하는 helper에 가깝습니다.
-
----
-
-## Modal surface는 별도입니다
-
-InnoRouter 3.0에서 중요하게 봐야 할 부분 중 하나는 modal routing을 stack routing과 분리했다는 점입니다.
-
-`sheet`와 `fullScreenCover`는 `ModalStore`와 `ModalHost`로 다룹니다.
-
-```swift
-@Routable
-enum AppModalRoute {
-    case profile
-    case onboarding
-}
-
-struct ShellView: View {
-    @State private var modalStore = ModalStore<AppModalRoute>()
-
-    var body: some View {
-        ModalHost(store: modalStore) { route in
-            switch route {
-            case .profile:
-                ProfileView()
-            case .onboarding:
-                OnboardingView()
-            }
-        } content: {
-            HomeView()
-        }
-    }
-}
-```
-
-뷰에서는 `@EnvironmentModalIntent`로 presentation intent를 보냅니다.
-
-```swift
-struct HomeView: View {
-    @EnvironmentModalIntent(AppModalRoute.self) private var modalIntent
-
-    var body: some View {
-        VStack {
-            Button("Profile") {
-                modalIntent.send(.present(.profile, style: .sheet))
-            }
-
-            Button("Dismiss") {
-                modalIntent.send(.dismiss)
-            }
-        }
-    }
-}
-```
-
-여기서 얻는 장점은 분명합니다.
-
-- stack path와 modal queue를 섞지 않습니다.
-- `sheet`와 `fullScreenCover` 라이프사이클을 별도 관찰 지점으로 다룹니다.
-- modal은 stack middleware와 다른 성격이므로 의도적으로 middleware를 노출하지 않습니다.
-
----
-
-## Deep link는 실행이 아니라 계획입니다
-
-예전 InnoRouter 설명에서 딥링크는 "URL이 들어오면 화면 이동" 정도로 보이기 쉽습니다. 현재 모델은 더 명확합니다.
-
-1. `DeepLinkMatcher`가 URL을 route로 해석합니다.
-2. `DeepLinkPipeline`이 scheme/host/auth policy를 적용합니다.
-3. 결과는 `.plan`, `.pending`, `.rejected`, `.unhandled` 중 하나로 나옵니다.
-4. 앱은 그 계획을 언제 실행할지 직접 결정합니다.
-
-### Matcher
-
-```swift
-let matcher = DeepLinkMatcher<ProductRoute> {
-    DeepLinkMapping("/products") { _ in .list }
-    DeepLinkMapping("/products/:id") { params in
-        params.firstValue(forName: "id").map { .detail(id: $0) }
-    }
-}
-```
-
-`DeepLinkMatcher`는 단순 매칭기 이상입니다. 현재 구현은 아래 authoring 문제를 진단할 수 있습니다.
-
-- duplicate pattern
-- wildcard shadowing
-- parameter shadowing
-
-즉, "동작은 되는데 나중에 이상한 URL이 앞 규칙에 먹히는" 문제를 문서화된 surface로 다룹니다.
-
-### Pipeline
-
-```swift
-let pipeline = DeepLinkPipeline<ProductRoute>(
-    allowedSchemes: ["myapp", "https"],
-    allowedHosts: ["myapp.com"],
-    resolve: { matcher.match($0) },
-    authenticationPolicy: .required(
-        shouldRequireAuthentication: { route in
-            if case .detail = route { return true }
-            return false
-        },
-        isAuthenticated: { authManager.isLoggedIn }
-    ),
-    plan: { route in NavigationPlan(commands: [.push(route)]) }
-)
-```
-
-`DeepLinkPipeline`의 핵심은 URL을 바로 실행하지 않는다는 점입니다.
-
-- `.plan`: 지금 실행 가능한 계획
-- `.pending`: 로그인 후 재개해야 하는 계획
-- `.rejected`: 허용되지 않는 scheme/host
-- `.unhandled`: 매칭 실패
-
-SwiftUI에서 보통 이렇게 씁니다.
-
-```swift
-.onOpenURL { url in
-    switch pipeline.decide(for: url) {
-    case .plan(let plan):
-        _ = store.executeBatch(plan.commands)
-
-    case .pending(let pending):
-        self.pendingDeepLink = pending
-
-    case .rejected(let reason):
-        logger.error("Rejected deep link: \(String(describing: reason))")
-
-    case .unhandled(let url):
-        logger.error("Unhandled deep link: \(url.absoluteString)")
-    }
-}
-```
-
-이 구조 덕분에 "로그인 후 다시 실행"도 임시 if-else가 아니라 `PendingDeepLink` 재개 시나리오로 모델링할 수 있습니다.
-
----
-
-## Middleware는 cross-cutting policy layer입니다
-
-현재 InnoRouter의 middleware는 단순 훅이 아니라 command boundary입니다.
-
-### 할 수 있는 것
-
-- command를 실행 전에 재작성
-- 조건이 맞지 않으면 typed cancellation으로 중단
-- 실행 후 결과를 가공하거나 로깅
-
-### 할 수 없는 것
-
-- store 상태를 직접 mutate
-
-예를 들어 중복 push를 막을 수 있습니다.
-
-```swift
-store.addMiddleware(
-    AnyNavigationMiddleware(
-        willExecute: { command, state in
-            if case .push(let next) = command, state.path.last == next {
-                return .cancel(.conditionFailed)
-            }
-            return .proceed(command)
-        }
-    ),
-    debugName: "PreventDuplicatePush"
-)
-```
-
-핵심은 middleware가 "뷰 바깥 정책 계층"이라는 점입니다. 인증 가드, 분석 이벤트, 사전 조건 검사는 여기서 처리하고, 화면은 intent만 보냅니다.
-
----
-
-## App boundary에서는 effect 모듈을 씁니다
-
-앱 셸이나 coordinator boundary에서 store에 직접 접근하고 싶지 않다면 effect 모듈이 있습니다.
-
-### `InnoRouterNavigationEffects`
-
-이 모듈은 navigation command 실행을 감싸는 작은 facade입니다.
-
-- `execute(_:)`
-- `execute(_ commands:)`
-- `executeTransaction(_:)`
-- `executeGuarded(_:, prepare:)`
-
-즉, 앱 경계 코드가 `NavigationStore` 내부 세부사항보다 "어떤 명령을 어떤 조건에서 실행할지"에 집중하게 도와줍니다.
-
-### `InnoRouterDeepLinkEffects`
-
-이 모듈은 deep-link planning과 boundary execution을 연결합니다.
-
-- deep-link plan 실행
-- typed outcome 수신
-- 인증 후 pending deep link 재개
-
-딥링크가 단순 URL parsing이 아니라 앱 경계 정책이라는 점을 코드 구조로 분리한 셈입니다.
-
----
-
-## 매크로는 public-facing 기본 스타일입니다
-
-현재 public examples는 hand-written `Route` 준수보다 `@Routable`를 기본 스타일로 사용합니다.
-
-```swift
-import InnoRouter
-import InnoRouterMacros
-
-@Routable
-enum HomeRoute {
-    case list
-    case detail(id: String)
-    case settings
-}
-```
-
-`@Routable`는 route enum의 수동 `Route` 선언을 제거합니다. README와 `Examples/`도 이 스타일을 기준으로 작성됩니다.
-
-`@CasePathable`은 enum extraction과 조합이 필요할 때 쓰는 보조 매크로입니다. 모든 예제에 꼭 필요하진 않지만, route hierarchy를 더 다루기 쉽게 만드는 선택지로 보면 됩니다.
-
----
-
-## 언제 무엇을 쓰면 될까요?
-
-| 상황 | 권장 surface |
-|---|---|
-| 단일 stack 기반 앱 | `NavigationStore` + `NavigationHost` |
-| 이동 전에 정책 판단 필요 | `CoordinatorHost` + `Coordinator.handle(_:)` |
-| iPad/macOS detail stack | `NavigationSplitHost` 또는 `CoordinatorSplitHost` |
-| `sheet`/`fullScreenCover` 분리 | `ModalStore` + `ModalHost` |
-| URL 진입과 인증 재개 | `DeepLinkMatcher` + `DeepLinkPipeline` |
-| 앱 셸 경계에서 실행 facade 필요 | `InnoRouterNavigationEffects`, `InnoRouterDeepLinkEffects` |
-
-이 표만 기억해도 설계가 훨씬 단순해집니다. InnoRouter는 모든 흐름을 하나의 giant coordinator로 몰아넣는 프레임워크가 아니라, 상태와 권한 경계를 typed surface로 나누는 프레임워크입니다.
-
----
-
-## 설치와 요구사항
+## 설치와 import
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", from: "3.0.0")
+    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", from: "4.2.1")
 ]
 ```
 
-현재 요구사항은 다음과 같습니다.
+일반 앱 코드는 umbrella product인 `InnoRouter`를 import합니다. route macro가 필요한 파일에서만 `InnoRouterMacros`를 추가합니다.
 
-- iOS 18+
-- macOS 15+
-- tvOS 18+
-- watchOS 11+
-- Swift 6.2+
+```swift
+import InnoRouter
+import InnoRouterMacros
 
-Swift 6.2와 strict concurrency 전제를 두고 설계되어 있고, `Sendable`, `@MainActor`, typed result surface가 런타임 전반에 반영되어 있습니다.
+@Routable
+enum PeopleRoute {
+    case detail(UserSummary)
+}
+```
 
----
+macro import를 필요한 파일로 제한하면 비-macro 파일이 macro plugin resolution 비용을 함께 지지 않아도 됩니다.
 
-## 마무리
+## Best practice 1. View가 path를 직접 소유하지 않게 합니다
 
-InnoRouter를 한 문장으로 요약하면 이렇습니다.
+SwiftUI view가 직접 `NavigationPath`를 들고 push/pop을 처리하면 처음에는 간단하지만, feature가 커질수록 path mutation이 분산됩니다.
 
-> InnoRouter는 SwiftUI 내비게이션 helper가 아니라, route state와 command execution을 중심으로 앱 경계를 정리하는 typed navigation runtime입니다.
+InnoRouter의 기본 방향은 다릅니다.
 
-그래서 좋은 점도 분명합니다.
+- route는 enum으로 선언합니다.
+- store가 route stack을 소유합니다.
+- host가 SwiftUI navigation API와 연결합니다.
+- coordinator가 user intent를 navigation command로 바꿉니다.
 
-1. 내비게이션 상태를 `RouteStack`으로 명시적으로 다룰 수 있습니다.
-2. command, batch, transaction semantics를 구분해 테스트와 운영이 쉬워집니다.
-3. stack, modal, deep link를 서로 다른 권한 경계로 분리할 수 있습니다.
-4. coordinator와 effect boundary에서 앱 정책을 화면 바깥으로 밀어낼 수 있습니다.
+```swift
+final class PeopleFeatureCoordinator {
+    let navigationStore = NavigationStore<PeopleRoute>()
+    let modalStore = ModalStore<PeopleModalRoute>()
 
-복잡한 앱에서 내비게이션이 자꾸 "UI 코드의 일부"처럼 흩어진다면, InnoRouter는 그 문제를 상태와 실행 모델의 문제로 다시 정의하게 도와줍니다.
+    func showDetail(user: UserSummary) {
+        navigationStore.send(.go(.detail(user)))
+    }
+}
+```
 
-## 참고 자료
+view는 `NavigationHost`나 `ModalHost` 안에서 route를 화면으로 해석합니다. 이렇게 하면 push/pop이 view local state가 아니라 feature boundary의 state가 됩니다.
 
-- [InnoRouter GitHub 저장소](https://github.com/InnoSquadCorp/InnoRouter)
-- [InnoRouter 최신 DocC](https://innosquadcorp.github.io/InnoRouter/latest/)
-- [SwiftUI NavigationStack](https://developer.apple.com/documentation/swiftui/navigationstack)
+## Best practice 2. Leaf feature는 자기 navigation만 압니다
+
+feature가 다른 feature router를 직접 import하면 dependency cycle이 빠르게 생깁니다. InnoSample은 이 문제를 상위 coordinator 중재로 해결합니다.
+
+`PeopleFeature`는 settings 화면을 직접 push하지 않습니다. 대신 reducer가 `pendingSettingsRequest`를 만들고, `PeopleFeatureCoordinator`가 이 request를 소비할 수 있게 합니다. 실제 탭 전환과 `SettingsFeature` detail push는 상위 `EntireTabCoordinator`가 처리합니다.
+
+```swift
+@MainActor
+@Observable
+public final class EntireTabCoordinator: TabCoordinator {
+    let peopleCoordinator: PeopleFeatureCoordinator
+    let postsCoordinator: PostsFeatureCoordinator
+    let settingsCoordinator: SettingsFeatureCoordinator
+
+    func syncCrossFeatureNavigationFromPeople() {
+        guard let request = peopleCoordinator.consumeSettingsRequest() else { return }
+        selectedTab = .settings
+        settingsCoordinator.showDetail(assigneeID: request.assigneeID)
+    }
+
+    func syncCrossFeatureNavigationFromSettings() {
+        guard let request = settingsCoordinator.consumePeopleRequest() else { return }
+        selectedTab = .people
+        peopleCoordinator.showDetail(userID: request.userID)
+    }
+}
+```
+
+이 구조의 핵심은 런타임 이동과 컴파일 의존을 분리하는 것입니다.
+
+- 런타임: `People -> Settings -> People` 이동 가능
+- 컴파일: `People -> EntireTab <- Settings` 구조 유지
+
+이것이 multi-feature SwiftUI 앱에서 InnoRouter를 쓰는 가장 큰 이유 중 하나입니다.
+
+## Best practice 3. Navigation intent와 business state를 분리합니다
+
+navigation은 business logic의 결과일 수 있지만, navigation stack 자체가 business state는 아닙니다.
+
+좋은 흐름은 다음과 같습니다.
+
+1. InnoFlow reducer가 "이동하고 싶다"는 intent를 만든다.
+2. feature coordinator가 intent를 소비한다.
+3. InnoRouter store에 route command를 보낸다.
+4. SwiftUI host가 route를 화면으로 렌더링한다.
+
+이렇게 나누면 reducer test는 navigation framework 없이도 가능하고, router test는 business use case 없이도 가능합니다.
+
+## Best practice 4. Modal, tab, stack을 같은 언어로 둡니다
+
+SwiftUI 앱에서 push는 `NavigationStack`, modal은 `.sheet`, tab은 `TabView`로 흩어지기 쉽습니다. InnoRouter는 이들을 route/coordinator 중심으로 묶습니다.
+
+- `NavigationStore`: push stack
+- `ModalStore`: sheet/fullScreenCover authority
+- `TabCoordinator`: selected tab, tab content, badge state
+- `DeepLinkPipeline`: app boundary의 URL planning
+
+제품이 분리되어 있지만 사고방식은 같습니다. "화면 이동은 데이터이고, host가 실행한다"는 원칙입니다.
+
+## Best practice 5. Deep link는 app boundary에서 계획합니다
+
+deep link를 feature view 안에서 파싱하면 앱 전체 route policy가 흩어집니다. InnoRouter의 deep-link surface는 matching과 planning을 app boundary로 끌어올립니다.
+
+실무에서는 보통 다음 방식이 좋습니다.
+
+- URL parsing과 route planning은 app/root coordinator에서 처리합니다.
+- feature는 자신이 처리 가능한 route intent만 받습니다.
+- auth/session gating은 InnoRouter가 아니라 app policy에서 결정합니다.
+- pending deep link는 명시적으로 저장하고 재개합니다.
+
+이 구조는 deep link가 늘어날수록 더 가치가 커집니다.
+
+## 도입했을 때 얻는 장점
+
+InnoRouter를 잘 쓰면 다음 장점이 생깁니다.
+
+- route가 enum/type으로 남습니다.
+- view가 path mutation을 직접 들고 있지 않습니다.
+- navigation을 host 없이 테스트할 수 있습니다.
+- sibling feature 이동에서 compile dependency cycle을 줄입니다.
+- modal, tab, push, deep link를 같은 구조로 설명할 수 있습니다.
+- SwiftUI navigation의 side effect를 coordinator 경계에 모을 수 있습니다.
+
+특히 feature가 많고 탭/딥링크/모달이 섞이는 앱에서는 이 장점이 큽니다. navigation이 화면 구현의 부산물이 아니라, 앱 흐름의 명시적인 모델이 됩니다.
+
+## 언제 쓰면 좋은가
+
+InnoRouter는 이런 앱에 잘 맞습니다.
+
+- SwiftUI navigation이 여러 feature에 걸쳐 있는 앱
+- tab, modal, push, deep link가 함께 필요한 앱
+- feature 간 직접 import를 줄이고 싶은 앱
+- navigation 흐름을 테스트하고 싶은 팀
+- strict concurrency와 typed route model을 선호하는 팀
+
+반대로 화면 두세 개짜리 단순 앱에서는 SwiftUI navigation API만으로 충분할 수 있습니다.
+
+## InnoSample에서의 결론
+
+[`InnoSample`]({% post_url 2026-04-03-innosample-inno-libraries-in-practice %})에서 InnoRouter는 `Router` 타깃에만 들어갑니다.
+
+- `PeopleFeatureRouter`는 People navigation만 압니다.
+- `PostsFeatureRouter`는 Posts navigation만 압니다.
+- `SettingsFeatureRouter`는 Settings navigation만 압니다.
+- `EntireTabCoordinator`가 sibling 이동을 중재합니다.
+- `FeatureContainer`가 leaf coordinator들을 조립합니다.
+
+이것이 InnoRouter의 좋은 사용법입니다. **leaf feature는 자기 route만 소유하고, cross-feature navigation은 상위 coordinator가 맡습니다.** 그러면 앱은 유연하게 이동하면서도 컴파일 의존은 단단하게 유지됩니다.

--- a/_posts/2026-04-03-innosample-inno-libraries-in-practice-en.md
+++ b/_posts/2026-04-03-innosample-inno-libraries-in-practice-en.md
@@ -1,9 +1,9 @@
 ---
-title: "How InnoSample uses InnoDI, InnoFlow, InnoRouter, and InnoNetwork in a real app architecture"
+title: "How InnoSample Combines InnoDI, InnoFlow, InnoRouter, and InnoNetwork"
 date: 2026-04-03 00:00:00 +0900
 translation_key: innosample-inno-libraries-in-practice
 lang: en
-description: "A practical guide to how InnoSample wires InnoDI, InnoFlow, InnoRouter, and InnoNetwork together inside a modular Swift iOS app architecture."
+description: "How InnoSample places InnoDI, InnoFlow, InnoRouter, and InnoNetwork at the right architecture boundaries, and why the combination creates a stronger app baseline."
 categories: [iOS, Swift, Architecture]
 tags: [swift, iOS, architecture, modularization, dependency-injection, navigation, networking, tuist, clean-architecture, swiftui]
 author: ethan
@@ -11,376 +11,233 @@ toc: true
 comments: true
 ---
 
-## Why this post exists
+## The core idea
 
-There are already separate posts for [`InnoDI`](https://github.com/InnoSquadCorp/InnoDI), [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow), [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter), and [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork). But in a real Swift iOS app architecture, the harder problem is not learning each library in isolation. The harder problem is deciding **which boundary each library should own**.
+[`InnoDI`](https://github.com/InnoSquadCorp/InnoDI), [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow), [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter), and [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork) are useful on their own. In a real iOS app, though, the more important question is not only how to call each API.
 
-That is what [`InnoSample`](https://github.com/InnoSquadCorp/InnoSample) is good at showing.
+**Which boundary should each library own so they do not step on each other?**
 
-`InnoSample` is not mainly a feature showcase. It is a baseline scaffold that fixes the parts that tend to drift early in a project:
+[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample) exists to answer that question. It is not a feature-heavy sample app. It is a baseline scaffold for the boundaries real apps need early: composition, state, navigation, and networking.
 
-- module boundaries
-- DI wiring
-- navigation ownership
-- network boundaries
+The individual best-practice posts go deeper on each library:
 
-This post uses the actual `InnoSample` codebase to answer four practical questions.
+- [InnoDI Best Practices: Using Swift Macro DI to Preserve App Structure]({% post_url 2026-02-23-innodi-swift-macro-di-en %})
+- [InnoFlow Best Practices: Managing SwiftUI Feature Logic with One-Way State]({% post_url 2026-02-23-innoflow-unidirectional-architecture-en %})
+- [InnoRouter Best Practices: Managing SwiftUI Navigation with Routes and Coordinators]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %})
+- [InnoNetwork Best Practices: Designing Swift Concurrency Networking Boundaries]({% post_url 2026-02-23-innonetwork-type-safe-networking-en %})
+- [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity-en %})
+- [Clean Architecture]({% post_url 2024-05-13-clean-architecture-en %})
 
-- Where should `InnoDI` live?
-- Which layer should own `InnoFlow` reducers?
-- How should `InnoRouter` handle cross-feature navigation?
-- How far should `InnoNetwork` be exposed in app code?
+This post focuses on what happens when the four libraries are placed together.
 
-The detailed public surface of each library is already covered in separate posts. This article is the integration guide: how the four libraries work **together** inside one modular app.
+## The versions used by InnoSample
 
-- `InnoDI`: [InnoDI: A Type-Safe Dependency Injection Library Built with Swift Macros]({% post_url 2026-02-23-innodi-swift-macro-di-en %})
-- `InnoFlow`: [InnoFlow: A unidirectional architecture framework for SwiftUI]({% post_url 2026-02-23-innoflow-unidirectional-architecture-en %})
-- `InnoRouter`: [InnoRouter: A type-safe navigation framework for SwiftUI]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %})
-- `InnoNetwork`: [InnoNetwork: A type-safe networking framework for Swift Concurrency]({% post_url 2026-02-23-innonetwork-type-safe-networking-en %})
-- Modularity background: [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity-en %})
-- Layering background: [Clean Architecture]({% post_url 2024-05-13-clean-architecture-en %})
-
-## Start with the dependency direction
-
-`InnoSample` is organized around this dependency flow.
-
-- `Feature -> Domain`
-- `Data -> Domain`
-- `Remote -> Data + CoreNetwork`
-- `Layers -> Domain + Data + Remote`
-- `Features -> Domain + Feature`
-- `App -> CoreNetwork + Layers + Features + ThirdParty`
-
-Two things matter here.
-
-First, `CoreNetwork`, `Layers`, and `Features` are not just implementation modules. They are mostly **composition and boundary modules**.
-
-Second, runtime movement between features is allowed, but compile-time dependency cycles are not. A flow like `PeopleFeature -> SettingsFeature` may happen at runtime, but `PeopleFeature` does not directly import `SettingsFeature`.
-
-That separation between runtime flow and compile-time dependency is one of the most useful things the sample teaches.
-
-## The package versions used by the sample
-
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)'s `Tuist/Package.swift` pins these versions:
+`Tuist/Package.swift` pins the Inno packages as remote dependencies.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", exact: "3.0.1"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoFlow", exact: "3.0.2"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", exact: "3.1.0"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", exact: "3.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", exact: "4.3.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoFlow", exact: "4.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", exact: "4.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", exact: "4.2.1"),
 ]
 ```
 
-The important point is not only that the packages are added. The important point is that `InnoSample` does not let every feature consume these libraries however it wants. It distributes them through the `App -> Layers -> Features` structure on purpose.
+The sample does not let every feature import every library freely. Each library sits where its responsibility fits.
 
-So if someone lands on this page searching for phrases like "InnoDI tutorial", "InnoFlow architecture", "InnoRouter SwiftUI example", or "InnoNetwork usage", the right framing is this:
+- `InnoDI`: `AppContainer`, `LayerContainer`, `FeatureContainer`
+- `InnoFlow`: feature `Logic`
+- `InnoRouter`: feature `Router`
+- `InnoNetwork`: `Remote`
+- `Utils`: shared `SampleDesignSupport` for feature UI
 
-> This is not a library-by-library tutorial. It is a practical guide to how those libraries should be placed inside a modular Swift app architecture.
+That placement is the whole point.
 
-## 1. Use InnoDI at composition roots and container boundaries
+## The app shape
 
-The first file to look at is `AppContainer`. It is the clearest example of where [`InnoDI`](https://github.com/InnoSquadCorp/InnoDI) should live in a real app.
+The main dependency direction is:
+
+- `Feature -> Domain`
+- `Data -> Domain`
+- `Remote -> Data + InnoNetwork`
+- `Layers -> Domain + Data + Remote`
+- `Features -> Domain + Feature`
+- `App -> Layers + Features + ThirdParties`
+- `Feature UI -> Utils`
+
+```mermaid
+graph TD
+    App["App"]
+    AppContainer["AppContainer"]
+    Layers["Layers"]
+    LayerContainer["LayerContainer"]
+    Remote["Remote + InnoNetwork"]
+    Data["Data"]
+    Domain["Domain"]
+    Features["Features"]
+    FeatureContainer["FeatureContainer"]
+    Logic["Feature Logic + InnoFlow"]
+    Router["Feature Router + InnoRouter"]
+    UI["Feature UI"]
+    ThirdParties["ThirdParties"]
+    Utils["Utils / SampleDesignSupport"]
+
+    App --> AppContainer
+    AppContainer --> Layers
+    AppContainer --> Features
+    AppContainer --> ThirdParties
+    Layers --> LayerContainer
+    LayerContainer --> Remote
+    LayerContainer --> Data
+    LayerContainer --> Domain
+    Features --> FeatureContainer
+    FeatureContainer --> Logic
+    FeatureContainer --> Router
+    Router --> UI
+    UI --> Utils
+    Logic --> Domain
+```
+
+`Layers` and `Features` are not just folders. They are composition boundaries. `Utils` separates cross-cutting UI support such as shared design helpers without turning it into business state. The point is to hide implementation detail and expose only the next useful surface.
+
+## 1. InnoDI fixes construction boundaries
+
+InnoDI is not used as a global dependency access mechanism. In InnoSample, it appears strongly at composition roots and container boundaries.
 
 ```swift
 @MainActor
-@DIContainer(root: true)
+@DIContainer(root: true, mainActor: true)
 struct AppContainer {
     @Provide(.input)
     var baseURL: URL
 
-    @Provide(.shared, factory: {
-        AnalyticsClient(apiKey: "innosample-demo-key")
-    }, concrete: true)
-    var analyticsClient: AnalyticsClient
-
     @Provide(.shared, factory: { (baseURL: URL) in
-        NetworkFactory.makeTransport(baseURL: baseURL)
-    }, concrete: true)
-    var networkTransport: NetworkTransport
-
-    @Provide(.shared, factory: { (networkTransport: NetworkTransport) in
-        LayerContainer.make(networkTransport: networkTransport)
+        LayerContainer(baseURL: baseURL)
     }, concrete: true)
     var layerContainer: LayerContainer
 
     @Provide(.shared, factory: { (layerContainer: LayerContainer) in
-        FeatureContainer.make(useCases: layerContainer.featureUseCases)
-    }, concrete: true)
+        layerContainer.featureUseCases
+    })
+    var featureUseCases: any FeatureUseCaseContaining
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \FeatureContainer.useCases, parent: \AppContainer.featureUseCases)],
+        featureRoot: FeatureRootScene.self
+    )
     var featureContainer: FeatureContainer
 }
 ```
 
-This is a good example of what `InnoDI` should be doing in a real codebase.
+`AppContainer` fixes the creation order for the app. It does not know every remote data source or every leaf coordinator detail.
 
-It is not being used as a runtime service locator. It is being used where wiring should be declared explicitly.
+This gives the app:
 
-The pattern is simple:
+- a visible startup graph
+- explicit container ownership
+- generated SwiftUI root-scene wiring
+- less DI framework exposure inside feature logic
 
-- external values like `baseURL` enter as `.input`
-- long-lived infrastructure becomes `.shared`
-- the app composes in one direction only: `NetworkTransport -> LayerContainer -> FeatureContainer`
-- the root container does not need to know the internal steps of `RemoteContainer`, `DataContainer`, and `DomainContainer`
+In the combined architecture, InnoDI answers: "who creates whom?"
 
-That is the right mental model for `InnoDI`: not "object creation convenience," but **explicit dependency graph declaration**.
+## 2. InnoNetwork keeps external API policy inside Remote
 
-If you want the detailed rules around scopes, declaration order, `concrete: true`, and validation, the dedicated [InnoDI post]({% post_url 2026-02-23-innodi-swift-macro-di-en %}) goes deeper. This article stays focused on where that wiring belongs architecturally.
-
-## 2. Layers use InnoDI internally, but expose only a narrow surface
-
-`LayerContainer` connects `Remote -> Data -> Domain`.
-
-```swift
-public struct LayerContainer {
-    private let remoteContainer: RemoteContainer
-    private let dataContainer: DataContainer
-    private let domainContainer: DomainContainer
-
-    public init(networkTransport: NetworkTransport) {
-        self.remoteContainer = RemoteContainer(networkTransport: networkTransport)
-        self.dataContainer = DataContainer(remoteContainer: remoteContainer)
-        self.domainContainer = DomainContainer(dataContainer: dataContainer)
-    }
-
-    public var featureUseCases: any FeatureUseCaseContaining {
-        domainContainer
-    }
-}
-```
-
-This matters because `App` and `Features` do not need to know the concrete `DomainContainer` type. They only receive `featureUseCases`.
-
-The underlying composition is pushed down one level at a time.
-
-### `RemoteContainer`
+Network code spreads quickly when features call clients directly. InnoSample keeps InnoNetwork inside `Remote`.
 
 ```swift
 @DIContainer
 public struct RemoteContainer {
     @Provide(.input)
-    public var networkTransport: NetworkTransport
+    public var baseURL: URL
 
-    @Provide(.shared, factory: { (networkTransport: NetworkTransport) in
-        UserRemoteFactory.make(networkTransport: networkTransport)
+    @Provide(.shared, factory: { (baseURL: URL) in
+        RemoteClientFactory.makeClient(baseURL: baseURL)
+    })
+    var networkClient: any NetworkClient
+
+    @Provide(.shared, factory: { (networkClient: any NetworkClient) in
+        UserRemoteFactory.make(networkClient: networkClient)
     })
     public var userRemoteDataSource: any UserRemoteDataSourceProtocol
 }
 ```
 
-### `DataContainer`
+`RemoteClientFactory` owns operational policy such as retry, interceptors, and timeout.
 
 ```swift
-@DIContainer
-public struct DataContainer {
-    @Provide(.input)
-    public var remoteContainer: any RemoteDataSourceContaining
-
-    @Provide(.shared, factory: { (remoteContainer: any RemoteDataSourceContaining) in
-        UserRepositoryFactory.make(remoteContainer: remoteContainer)
-    })
-    public var userRepository: any UserRepositoryProtocol
-}
+let configuration = NetworkConfiguration.advanced(
+    baseURL: environment.baseURL,
+    resilience: ResiliencePack(
+        retry: ExponentialBackoffRetryPolicy(maxRetries: 2)
+    ),
+    auth: AuthPack(
+        additionalSigners: [RemoteMetadataInterceptor(environment: environment)],
+        additionalResponseInterceptors: [RemoteStatusInterceptor()]
+    ),
+    transport: TransportPack(timeout: 20.0)
+)
 ```
 
-### `DomainContainer`
+Features do not know HTTP. `Domain` does not know `NetworkClient`. External API execution finishes inside `Remote`, and `Data` sees only remote data source contracts.
+
+In the combined architecture, InnoNetwork answers: "how do we communicate with the outside world?"
+
+## 3. Data and Domain translate transport into app language
+
+`Remote` performs API calls, `Data` owns repository implementations and remote data source contracts, and `Domain` exposes entities, repository protocols, and use cases.
+
+The layers keep their jobs separate:
+
+- `Remote`: API requests, DTOs, failure mapping
+- `Data`: repository implementation and DTO-to-domain mapping
+- `Domain`: use cases, domain models, repository protocols
+- `Feature`: use case calls
+
+Use cases are concrete action objects that features can call. Repositories remain protocols because they are real layer-boundary contracts.
+
+This keeps feature code in app language: "load people", "load posts", "load todos", not "perform this HTTP request".
+
+## 4. InnoFlow controls feature state transitions
+
+Feature `Logic` targets use InnoFlow. `PeopleFeatureReducer` manages loading, loaded, failed, selected user, and settings-navigation intent in one reducer.
 
 ```swift
-@DIContainer
-public struct DomainContainer: FeatureUseCaseContaining {
-    @Provide(.input)
-    public var dataContainer: any RepositoryContaining
-}
-
-extension DomainContainer {
-    public var fetchPeopleUseCase: FetchPeopleUseCase {
-        FetchPeopleUseCase(repository: dataContainer.userRepository)
-    }
-}
-```
-
-This gives the sample a few good properties.
-
-- repositories remain protocol-based because they are real cross-layer contracts
-- use cases stay lightweight concrete values because they are stateless wrappers
-- features depend on use cases, not repositories
-- the app root does not need to know remote/data/domain internals
-
-That is a good default: not one giant graph, but **small containers at each boundary with a narrow outward surface**.
-
-This is also consistent with the modularity-first approach discussed in [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity-en %}).
-
-## 3. Keep InnoFlow inside Logic targets
-
-In [`InnoSample`](https://github.com/InnoSquadCorp/InnoSample), [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow) belongs inside feature `Logic` targets. `PeopleFeatureReducer` is a representative example.
-
-```swift
-@InnoFlow
+@InnoFlow(phaseManaged: true)
 struct PeopleFeatureReducer {
     struct Dependencies: Sendable {
         let loadPeople: @Sendable () async throws -> [UserSummary]
     }
 
     struct State: Equatable, Sendable, DefaultInitializable {
-        var isLoading = false
-        var hasLoaded = false
+        enum Phase: Hashable, Sendable {
+            case idle
+            case loading
+            case loaded
+            case failed
+        }
+
+        var phase: Phase = .idle
         var people: [UserSummary] = []
         var errorMessage: String?
-        var selectedUser: UserSummary?
-        var pendingOverviewRequest: PeopleOverviewRequest?
         var pendingSettingsRequest: PeopleSettingsRequest?
     }
-
-    enum Action: Equatable, Sendable {
-        case onAppear
-        case refresh
-        case peopleLoaded([UserSummary])
-        case peopleFailed(String)
-        case select(UserSummary)
-        case showOverview
-        case openSettings(OpenSettingsRequest)
-    }
 }
 ```
 
-The important part is not just that the feature has `State` and `Action`. The more important part is that state also carries **one-shot intents** such as:
+The reducer does not know `NetworkClient` or `NavigationStore`.
 
-- `selectedUser`
-- `pendingOverviewRequest`
-- `pendingSettingsRequest`
+- Network work hides behind a use case closure.
+- Navigation is expressed as pending intent.
+- UI renders state and sends actions.
 
-Those are not `InnoRouter` commands. They are domain-friendly requests emitted by the reducer.
+In the combined architecture, InnoFlow answers: "how does this feature state change?"
 
-The async work also stays inside reducer-driven effects.
+## 5. InnoRouter turns screen movement into data
 
-```swift
-private func loadPeople() -> EffectTask<Action> {
-    let loadPeople = dependencies.loadPeople
-
-    return .run { send, _ in
-        do {
-            let people = try await loadPeople()
-            await send(.peopleLoaded(people))
-        } catch {
-            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            await send(.peopleFailed(message))
-        }
-    }
-    .cancellable("people-feature-load", cancelInFlight: true)
-}
-```
-
-That gives the sample a clean split.
-
-- reducers do not know `SwiftUI`
-- reducers do not know `InnoRouter`
-- reducers receive use case outputs back as actions
-- tests can target state transitions instead of UI side effects
-
-So the right way to think about `InnoFlow` here is not "screen control framework." It is a **feature logic boundary built around state transitions and effects**.
-
-If you want the deeper runtime model, including `Reducer`, `Store`, `EffectTask`, and `PhaseMap`, read the dedicated [InnoFlow post]({% post_url 2026-02-23-innoflow-unidirectional-architecture-en %}). The architectural lesson in `InnoSample` is that reducer ownership stays inside `Logic`.
-
-## 4. The model wraps the InnoFlow store, and the router owns screen movement
-
-`PeopleFeatureModel` wraps the reducer store into a SwiftUI-friendly interface.
+Feature `Router` targets use InnoRouter. Leaf features know their own routes; sibling movement is mediated by `EntireTabCoordinator`.
 
 ```swift
-@MainActor
-@Observable
-public final class PeopleFeatureModel {
-    private let store: Store<PeopleFeatureReducer>
-
-    public init(loadPeople: @escaping @Sendable () async throws -> [UserSummary]) {
-        self.store = Store(
-            reducer: PeopleFeatureReducer(
-                dependencies: .init(loadPeople: loadPeople)
-            )
-        )
-    }
-
-    public func loadIfNeeded() { store.send(.onAppear) }
-    public func select(_ user: UserSummary) { store.send(.select(user)) }
-
-    public func consumeSettingsRequest() -> OpenSettingsRequest? {
-        let request = store.pendingSettingsRequest?.request
-        guard let request else { return nil }
-        store.send(.clearSettingsRequest)
-        return request
-    }
-}
-```
-
-Then `PeopleFeatureCoordinator` owns the `InnoRouter` stores.
-
-```swift
-@MainActor
-@Observable
-public final class PeopleFeatureCoordinator {
-    let navigationStore = NavigationStore<PeopleRoute>()
-    let modalStore = ModalStore<PeopleModalRoute>()
-    let model: PeopleFeatureModel
-
-    func syncNavigationFromSelection() {
-        guard let selectedUser = model.consumeSelectedUser() else { return }
-        navigationStore.send(.resetTo([.detail(selectedUser)]))
-    }
-
-    func syncModalPresentation() {
-        guard let users = model.consumeOverviewUsers() else { return }
-        modalStore.send(.present(.overview(users), style: .sheet))
-    }
-}
-```
-
-This separation is important.
-
-The reducer never calls `navigationStore.send(...)` directly. It finishes at business intent. The coordinator reads that intent and translates it into route commands.
-
-That keeps the ownership clean:
-
-- `Logic` owns state and effects
-- `Model` owns SwiftUI-friendly projection
-- `Router/Coordinator` owns navigation state
-
-## 5. InnoRouter becomes even more valuable at the shell level
-
-At the leaf level, route hosts use [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter)'s `NavigationHost` and `ModalHost` in the expected way.
-
-```swift
-public struct PeopleFeatureRouteHost: View {
-    let coordinator: PeopleFeatureCoordinator
-
-    public var body: some View {
-        ModalHost(store: coordinator.modalStore) { route in
-            switch route {
-            case .overview(let users):
-                PeopleOverviewSheet(users: users) {
-                    coordinator.modalStore.send(.dismiss)
-                }
-            }
-        } content: {
-            NavigationHost(store: coordinator.navigationStore) { route in
-                switch route {
-                case .detail(let user):
-                    PeopleDetailScreen(user: user, onOpenSettings: coordinator.openSettings)
-                }
-            } root: {
-                PeopleScreen(
-                    model: coordinator.model,
-                    onSelect: coordinator.select,
-                    onShowOverview: coordinator.showOverview
-                )
-            }
-        }
-    }
-}
-```
-
-But the more interesting file is `EntireTabCoordinator`.
-
-```swift
-@MainActor
-@Observable
 public final class EntireTabCoordinator: TabCoordinator {
     let peopleCoordinator: PeopleFeatureCoordinator
     let postsCoordinator: PostsFeatureCoordinator
@@ -391,197 +248,74 @@ public final class EntireTabCoordinator: TabCoordinator {
         selectedTab = .settings
         settingsCoordinator.showDetail(assigneeID: request.assigneeID)
     }
-
-    func syncCrossFeatureNavigationFromSettings() {
-        guard let request = settingsCoordinator.consumePeopleRequest() else { return }
-        selectedTab = .people
-        peopleCoordinator.showDetail(userID: request.userID)
-    }
 }
 ```
 
-This is the real architectural win.
+This creates a useful separation:
 
-`PeopleFeature` does not directly import `SettingsFeature`, and `SettingsFeature` does not directly own `PeopleFeature` navigation. Instead:
+- `PeopleFeature` does not import `SettingsFeature`.
+- Runtime movement from People to Settings is still possible.
+- Compile-time dependency stays `People -> EntireTab <- Settings`.
+- InnoFlow creates navigation intent; InnoRouter executes it.
 
-1. the reducer emits a one-shot cross-feature request
-2. the feature coordinator consumes that request
-3. the shell coordinator mediates the tab switch and sibling entry
-4. the destination coordinator updates its own route state
+In the combined architecture, InnoRouter answers: "how should this movement be modeled and executed?"
 
-That prevents compile-time dependency cycles while still allowing bidirectional runtime movement.
+## The synergy
 
-The dedicated [InnoRouter post]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %}) explains the runtime surface itself in detail. What `InnoSample` adds is a strong example of **shell-level mediation** instead of direct sibling wiring.
+Putting four libraries in one app does not automatically create good architecture. The benefit comes from giving each library a different boundary.
 
-## 6. Keep InnoNetwork behind CoreNetwork
+InnoSample's split is:
 
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample) does not let [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork) leak everywhere. It introduces a `CoreNetwork` boundary first.
+| Responsibility | Owner |
+| --- | --- |
+| Construction and ownership | InnoDI |
+| External API execution policy | InnoNetwork |
+| App data transformation and use cases | Data / Domain |
+| Feature state transitions | InnoFlow |
+| Screen movement execution | InnoRouter |
+| Shared UI support | Utils |
+| Top-level composition | App / Layers / Features |
 
-`NetworkFactory` centralizes transport policy.
+The result:
 
-```swift
-public enum NetworkFactory {
-    public static func makeTransport(
-        environment: NetworkEnvironment,
-        session: URLSessionProtocol = URLSession.shared
-    ) -> NetworkTransport {
-        let defaults = makeDefaults(environment: environment)
-        return NetworkTransport(
-            client: makeClient(environment: environment, session: session),
-            defaults: defaults
-        )
-    }
+- the DI graph does not become a state machine
+- reducers do not mutate navigation stacks directly
+- network clients do not leak into features
+- routers do not own business logic
+- app root does not construct every leaf implementation directly
 
-    static func makeDefaults(environment: NetworkEnvironment) -> APIDefaults {
-        APIDefaults(
-            environment: environment,
-            logger: RequestLogger(),
-            requestInterceptors: [
-                NetworkMetadataInterceptor(environment: environment),
-            ],
-            responseInterceptors: [
-                NetworkStatusInterceptor(),
-            ]
-        )
-    }
-}
-```
+The larger value is not using each library in isolation. It is **placing them so they do not invade each other's jobs.**
 
-And it exposes only `NetworkTransport` upward.
+## Principles to reuse in your app
 
-```swift
-public actor NetworkTransport {
-    public func send<Request: RequestDefinition>(_ request: Request) async throws -> Request.ResponseBody {
-        do {
-            return try await client.perform(executable:
-                RequestAdapter(request: request, apiDefaults: defaults)
-            )
-        } catch let error as NetworkError {
-            throw NetworkFailure(networkError: error)
-        } catch {
-            throw NetworkFailure.transport(SendableUnderlyingError(error), request: nil)
-        }
-    }
-}
-```
+You do not need to copy InnoSample exactly. The reusable principles are:
 
-That means transport-specific concerns stay inside `CoreNetwork`:
+1. `App` owns root composition only.
+2. `Layers` wires `Remote/Data/Domain` and exposes feature-facing use cases.
+3. `Features` wires leaf feature inputs and routers.
+4. Leaf features are split into `Interface / Logic / UI / Router / Testing`.
+5. `Utils` holds stateless shared UI support such as design helpers.
+6. Cross-feature navigation is mediated by a parent coordinator.
+7. Network policy stays inside `Remote`.
+8. Reducers call use cases, not clients or containers.
 
-- retry policy
-- interceptors
-- logging
-- environment defaults
-- request/response adaptation
+Those rules keep files honest as the app grows.
 
-`Remote` only defines requests and executes them.
+## Conclusion
 
-Here is the full flow for loading people.
+InnoSample is not just a showcase for four libraries. It is an example of placing four libraries at four different architecture boundaries.
 
-### Request definition
+- InnoDI fixes construction boundaries.
+- InnoNetwork isolates external API execution.
+- InnoFlow controls feature state transitions.
+- InnoRouter executes navigation through typed routes and coordinators.
 
-```swift
-struct FetchUsersRequest: RequestDefinition {
-    typealias ResponseBody = [UserRemoteModel]
+The appeal is not that the stack has many features. The appeal is that it separates the responsibilities that usually become tangled in real apps: construction, state, navigation, and networking.
 
-    let featureName = "People"
-    var path: String { "/users" }
-    var headerPolicy: HeaderPolicy { .external }
-}
-```
+When reading InnoSample, the best question is not "how do I call this API?"
 
-### Remote data source
+The better question is:
 
-```swift
-public actor JSONPlaceholderUserRemoteDataSource: UserRemoteDataSourceProtocol {
-    private let transport: NetworkTransport
+**Can my app split these responsibilities the same way?**
 
-    public func fetchUsers() async throws -> [UserRemoteModel] {
-        try await transport.send(FetchUsersRequest())
-    }
-}
-```
-
-### Repository
-
-```swift
-public struct DefaultUserRepository: UserRepositoryProtocol, Sendable {
-    public func fetchUsers() async throws -> [UserSummary] {
-        let users = try await remoteDataSource.fetchUsers()
-        guard !users.isEmpty else {
-            throw DomainError.emptyResponse("사용자")
-        }
-        return users.map(\.domainModel)
-    }
-}
-```
-
-### Use case
-
-```swift
-public struct FetchPeopleUseCase: Sendable {
-    public func callAsFunction() async throws -> [UserSummary] {
-        try await repository.fetchUsers()
-    }
-}
-```
-
-By the time the request reaches `Feature`, the app no longer knows anything about `InnoNetwork`.
-
-That is exactly what you want in a real app. If transport policy changes later, most of the blast radius stays inside `CoreNetwork`.
-
-The product-family view of `InnoNetwork`, including `NetworkConfiguration`, retry policy, downloads, and websockets, is covered in the dedicated [InnoNetwork post]({% post_url 2026-02-23-innonetwork-type-safe-networking-en %}). Here the important lesson is boundary placement.
-
-## 7. The practical ownership model
-
-`InnoSample` suggests a simple ownership table.
-
-| Library | What it should own | What it should not own |
-|---|---|---|
-| `InnoDI` | container declarations, composition roots, layer wiring | screen logic, business state, service-locator-style runtime access |
-| `InnoFlow` | feature state, actions, effects, one-shot intents | route stacks, SwiftUI view composition |
-| `InnoRouter` | stack and modal state, coordinators, cross-feature mediation | business state machines, repository calls |
-| `InnoNetwork` | request execution, retry, interceptors, logging, transport policy | domain modeling, feature logic, app-shell composition |
-
-This matters because a codebase is not healthier just because it "uses all four libraries." It is healthier when each library stays inside its intended boundary.
-
-## 8. Good defaults to copy into a new app
-
-If you use `InnoSample` as the starting point for a real app, these are strong defaults:
-
-1. Keep a single `AppContainer` as the top-level composition root.
-2. Put `InnoNetwork` behind a dedicated `CoreNetwork` module.
-3. Keep `Layers` as a composition-only boundary.
-4. Physically split each feature into `Interface / Logic / UI / Router / Testing / Tests`.
-5. Do not import `SwiftUI` or `InnoRouter` inside feature `Logic`.
-6. Do not let sibling features navigate directly to each other.
-7. Keep repositories protocol-based, and keep stateless use cases as concrete values by default.
-
-Those defaults make it much easier to scale the architecture without mixing ownership boundaries too early.
-
-## Closing
-
-The most useful lesson in `InnoSample` is this:
-
-> The Inno libraries work best when they are not mixed together in the same place.
-
-In practice:
-
-- `InnoDI` declares wiring
-- `InnoFlow` drives state transitions
-- `InnoRouter` mediates screen flow
-- `InnoNetwork` encapsulates transport policy
-
-If all four are visible inside one file, that is often a warning sign. If they appear in clearly separated places across `App -> Layers -> Features`, the architecture tends to stay understandable as the app grows.
-
-For adjacent reading:
-
-- Architecture background: [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity-en %}), [Clean Architecture]({% post_url 2024-05-13-clean-architecture-en %})
-- Library-specific posts: [InnoDI]({% post_url 2026-02-23-innodi-swift-macro-di-en %}), [InnoFlow]({% post_url 2026-02-23-innoflow-unidirectional-architecture-en %}), [InnoRouter]({% post_url 2026-02-23-innorouter-swiftui-navigation-en %}), [InnoNetwork]({% post_url 2026-02-23-innonetwork-type-safe-networking-en %})
-
-## Repository links
-
-- [InnoSample GitHub repository](https://github.com/InnoSquadCorp/InnoSample)
-- [InnoDI GitHub repository](https://github.com/InnoSquadCorp/InnoDI)
-- [InnoFlow GitHub repository](https://github.com/InnoSquadCorp/InnoFlow)
-- [InnoRouter GitHub repository](https://github.com/InnoSquadCorp/InnoRouter)
-- [InnoNetwork GitHub repository](https://github.com/InnoSquadCorp/InnoNetwork)
+If the answer is yes, the Inno libraries become more than a tool collection. They become a practical starting point for preserving app structure over time.

--- a/_posts/2026-04-03-innosample-inno-libraries-in-practice.md
+++ b/_posts/2026-04-03-innosample-inno-libraries-in-practice.md
@@ -1,9 +1,9 @@
 ---
-title: "InnoSample 아키텍처로 보는 InnoDI, InnoFlow, InnoRouter, InnoNetwork 실전 사용법"
+title: "InnoSample로 보는 InnoDI, InnoFlow, InnoRouter, InnoNetwork 통합 시너지"
 date: 2026-04-03 00:00:00 +0900
 translation_key: innosample-inno-libraries-in-practice
 lang: ko-KR
-description: "InnoSample 코드 기준으로 InnoDI, InnoFlow, InnoRouter, InnoNetwork를 실제 iOS 앱 아키텍처에 어떻게 배치하고 연결해야 하는지 설명합니다."
+description: "InnoSample 코드 기준으로 InnoDI, InnoFlow, InnoRouter, InnoNetwork를 각각 어떤 경계에 배치해야 하고, 함께 쓸 때 어떤 아키텍처 시너지가 생기는지 설명합니다."
 categories: [iOS, Swift, Architecture]
 tags: [swift, iOS, architecture, modularization, dependency-injection, navigation, networking, tuist, clean-architecture, swiftui]
 author: ethan
@@ -11,365 +11,235 @@ toc: true
 comments: true
 ---
 
-## 들어가며
+## 이 글의 핵심
 
-[`InnoDI`](https://github.com/InnoSquadCorp/InnoDI), [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow), [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter), [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork)를 각각 따로 설명하는 글은 이미 많습니다. 그런데 실제 iOS 앱 아키텍처에서는 이 네 개를 "각자 잘 쓰는 것"보다 **어디까지를 누가 소유하는지**를 먼저 맞추는 일이 더 중요합니다.
+[`InnoDI`](https://github.com/InnoSquadCorp/InnoDI), [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow), [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter), [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork)는 각각 따로 써도 가치가 있습니다. 하지만 실제 iOS 앱에서는 "각 라이브러리를 잘 쓰는 법"보다 더 중요한 질문이 있습니다.
 
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)은 그 경계를 보여주기 위한 샘플입니다. 이 저장소의 목적은 기능을 많이 넣는 것이 아니라, Inno 계열 앱에서 반복해서 쓰게 되는 **Swift 모듈 아키텍처, DI wiring, navigation ownership, network boundary**를 먼저 고정하는 데 있습니다.
+**각 라이브러리가 어떤 경계를 소유해야 서로 침범하지 않는가?**
 
-이 글은 `InnoSample` 코드 기준으로 아래 질문에 답하는 방식으로 정리합니다.
+[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)은 이 질문에 답하기 위한 샘플입니다. 기능을 많이 보여주는 데 목적이 있지 않습니다. 실제 앱을 시작할 때 먼저 고정해야 하는 경계, composition, state, navigation, networking의 배치를 보여주는 baseline scaffold입니다.
 
-- `InnoDI`는 어디서 써야 하나
-- `InnoFlow`는 어떤 레이어에 둬야 하나
-- `InnoRouter`는 feature 간 이동을 어떻게 맡아야 하나
-- `InnoNetwork`는 앱 코드에 어디까지 드러나야 하나
+개별 라이브러리의 best practice는 아래 글에서 더 자세히 다룹니다.
 
-개별 라이브러리의 public surface 자체는 이미 별도 글로 정리해 두었습니다. 이 글은 그 글들을 대체하는 글이 아니라, **실제 앱 구조 안에서 네 라이브러리를 함께 배치하는 방법**에 집중합니다.
+- [InnoDI Best Practice: Swift Macro DI를 앱 구조로 고정하는 법]({% post_url 2026-02-23-innodi-swift-macro-di %})
+- [InnoFlow Best Practice: SwiftUI Feature Logic을 단방향으로 관리하기]({% post_url 2026-02-23-innoflow-unidirectional-architecture %})
+- [InnoRouter Best Practice: SwiftUI Navigation을 Route와 Coordinator로 다루기]({% post_url 2026-02-23-innorouter-swiftui-navigation %})
+- [InnoNetwork Best Practice: Swift Concurrency 네트워크 경계를 설계하는 법]({% post_url 2026-02-23-innonetwork-type-safe-networking %})
+- [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity %})
+- [Clean Architecture]({% post_url 2024-05-13-clean-architecture %})
 
-- `InnoDI` 자체 설명: [InnoDI: Swift Macro 기반 타입 안전 의존성 주입 라이브러리]({% post_url 2026-02-23-innodi-swift-macro-di %})
-- `InnoFlow` 자체 설명: [InnoFlow: SwiftUI를 위한 단방향 아키텍처 프레임워크]({% post_url 2026-02-23-innoflow-unidirectional-architecture %})
-- `InnoRouter` 자체 설명: [InnoRouter: SwiftUI를 위한 타입 안전 내비게이션 프레임워크]({% post_url 2026-02-23-innorouter-swiftui-navigation %})
-- `InnoNetwork` 자체 설명: [InnoNetwork: Swift Concurrency를 위한 타입 안전 네트워킹 프레임워크]({% post_url 2026-02-23-innonetwork-type-safe-networking %})
-- 모듈 분리 배경: [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity %})
-- 계층 분리 배경: [Clean Architecture]({% post_url 2024-05-13-clean-architecture %})
+이 글은 네 라이브러리를 함께 배치했을 때 생기는 시너지를 중심으로 봅니다.
 
-## 먼저 구조부터 봐야 합니다
+## 현재 InnoSample이 쓰는 버전
 
-`InnoSample`의 핵심 의존 방향은 아래처럼 잡혀 있습니다.
-
-- `Feature -> Domain`
-- `Data -> Domain`
-- `Remote -> Data + CoreNetwork`
-- `Layers -> Domain + Data + Remote`
-- `Features -> Domain + Feature`
-- `App -> CoreNetwork + Layers + Features + ThirdParty`
-
-이 구조에서 중요한 점은 두 가지입니다.
-
-첫째, `CoreNetwork`와 `Layers`, `Features`가 전부 "구현 레이어"가 아니라 **조립과 경계 정리를 위한 레이어**라는 점입니다.
-
-둘째, `PeopleFeature -> SettingsFeature` 같은 런타임 이동은 허용하지만, `PeopleFeature`가 `SettingsFeature`를 직접 import 하지는 않는다는 점입니다. 즉 **런타임 흐름과 컴파일 의존을 분리**합니다.
-
-## 샘플이 실제로 쓰는 패키지 버전
-
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)의 `Tuist/Package.swift` 기준으로 샘플은 아래 버전을 고정해서 사용합니다.
+`Tuist/Package.swift` 기준으로 InnoSample은 remote package를 exact version으로 고정합니다.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", exact: "3.0.1"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoFlow", exact: "3.0.2"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", exact: "3.1.0"),
-    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", exact: "3.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoDI.git", exact: "4.3.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoFlow", exact: "4.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoNetwork.git", exact: "4.0.0"),
+    .package(url: "https://github.com/InnoSquadCorp/InnoRouter.git", exact: "4.2.1"),
 ]
 ```
 
-여기서 중요한 건 단순히 "패키지를 추가했다"가 아닙니다. `InnoSample`은 Inno 라이브러리를 각 feature가 제각각 참조하게 두지 않고, **App -> Layers -> Features** 구조 안에서 역할별로 분배해서 사용합니다.
+샘플은 각 라이브러리를 feature가 마음대로 import하게 두지 않습니다. 역할이 맞는 모듈에만 배치합니다.
 
-즉 검색 키워드로 표현하면, 이 글은 "`InnoDI 사용법`", "`InnoFlow 사용법`", "`InnoRouter 사용법`", "`InnoNetwork 사용법`"을 각각 설명하는 글이라기보다, **"InnoSample 기반 Swift iOS 모듈 아키텍처에서 네 라이브러리를 어떻게 함께 쓰는가"**에 답하는 글입니다.
+- `InnoDI`: `AppContainer`, `LayerContainer`, `FeatureContainer`
+- `InnoFlow`: feature `Logic`
+- `InnoRouter`: feature `Router`
+- `InnoNetwork`: `Remote`
+- `Utils`: feature UI가 공유하는 `SampleDesignSupport`
 
-## 1. InnoDI는 composition root와 container 경계에 둡니다
+이 배치가 글 전체의 핵심입니다.
 
-가장 먼저 봐야 할 코드는 `AppContainer`입니다. [`InnoDI`](https://github.com/InnoSquadCorp/InnoDI)가 실제 앱에서 어디에 위치해야 하는지가 가장 잘 드러나는 지점입니다.
+## 전체 구조
+
+InnoSample의 큰 의존 방향은 아래와 같습니다.
+
+- `Feature -> Domain`
+- `Data -> Domain`
+- `Remote -> Data + InnoNetwork`
+- `Layers -> Domain + Data + Remote`
+- `Features -> Domain + Feature`
+- `App -> Layers + Features + ThirdParties`
+- `Feature UI -> Utils`
+
+Mermaid로 보면 다음과 같습니다.
+
+```mermaid
+graph TD
+    App["App"]
+    AppContainer["AppContainer"]
+    Layers["Layers"]
+    LayerContainer["LayerContainer"]
+    Remote["Remote + InnoNetwork"]
+    Data["Data"]
+    Domain["Domain"]
+    Features["Features"]
+    FeatureContainer["FeatureContainer"]
+    Logic["Feature Logic + InnoFlow"]
+    Router["Feature Router + InnoRouter"]
+    UI["Feature UI"]
+    ThirdParties["ThirdParties"]
+    Utils["Utils / SampleDesignSupport"]
+
+    App --> AppContainer
+    AppContainer --> Layers
+    AppContainer --> Features
+    AppContainer --> ThirdParties
+    Layers --> LayerContainer
+    LayerContainer --> Remote
+    LayerContainer --> Data
+    LayerContainer --> Domain
+    Features --> FeatureContainer
+    FeatureContainer --> Logic
+    FeatureContainer --> Router
+    Router --> UI
+    UI --> Utils
+    Logic --> Domain
+```
+
+이 구조에서 중요한 점은 `Layers`와 `Features`가 단순 폴더가 아니라 composition boundary라는 점입니다. `Utils`는 feature UI가 공유하는 디자인 지원처럼 cross-cutting하지만 business state를 갖지 않는 요소를 분리합니다. 내부 구현을 숨기고, 다음 경계가 필요한 surface만 노출하는 것이 핵심입니다.
+
+## 1. InnoDI는 생성 경계를 고정합니다
+
+InnoDI는 앱 어디서나 dependency를 꺼내는 도구가 아닙니다. InnoSample에서 InnoDI는 composition root와 container boundary에만 강하게 등장합니다.
 
 ```swift
 @MainActor
-@DIContainer(root: true)
+@DIContainer(root: true, mainActor: true)
 struct AppContainer {
     @Provide(.input)
     var baseURL: URL
 
-    @Provide(.shared, factory: {
-        AnalyticsClient(apiKey: "innosample-demo-key")
-    }, concrete: true)
-    var analyticsClient: AnalyticsClient
-
     @Provide(.shared, factory: { (baseURL: URL) in
-        NetworkFactory.makeTransport(baseURL: baseURL)
-    }, concrete: true)
-    var networkTransport: NetworkTransport
-
-    @Provide(.shared, factory: { (networkTransport: NetworkTransport) in
-        LayerContainer.make(networkTransport: networkTransport)
+        LayerContainer(baseURL: baseURL)
     }, concrete: true)
     var layerContainer: LayerContainer
 
     @Provide(.shared, factory: { (layerContainer: LayerContainer) in
-        FeatureContainer.make(useCases: layerContainer.featureUseCases)
-    }, concrete: true)
+        layerContainer.featureUseCases
+    })
+    var featureUseCases: any FeatureUseCaseContaining
+
+    @SubContainer(
+        scope: .shared,
+        bindings: [(child: \FeatureContainer.useCases, parent: \AppContainer.featureUseCases)],
+        featureRoot: FeatureRootScene.self
+    )
     var featureContainer: FeatureContainer
 }
 ```
 
-이 코드를 보면 `InnoDI`는 서비스 로케이터처럼 앱 전체에서 아무 데서나 꺼내 쓰는 도구가 아닙니다. 대신 **조립을 선언하는 위치**에만 등장합니다.
+여기서 `AppContainer`는 앱 전체의 생성 순서를 고정합니다. 하지만 `RemoteContainer`의 세부 data source나 `PeopleFeatureCoordinator`의 내부 상태를 직접 알지는 않습니다.
 
-이 샘플에서 `InnoDI` 사용 원칙은 아래처럼 읽으면 됩니다.
+좋은 점은 분명합니다.
 
-- `AppContainer`는 앱의 최상위 composition root다.
-- `baseURL` 같은 외부 입력은 `.input`으로 넣는다.
-- 오래 살아야 하는 인프라는 `.shared`로 둔다.
-- 상위는 `NetworkTransport -> LayerContainer -> FeatureContainer` 순서로만 조립한다.
-- 상위 컨테이너가 `RemoteContainer`, `DataContainer`, `DomainContainer` 내부 구조를 직접 알지 않게 만든다.
+- 앱 시작점에서 큰 graph가 보입니다.
+- container 간 ownership이 명시됩니다.
+- SwiftUI root scene 연결이 반복 코드 없이 됩니다.
+- feature는 DI framework를 직접 알 필요가 줄어듭니다.
 
-즉 `InnoDI`의 역할은 "객체 생성 편의"가 아니라 **의존 그래프를 코드로 고정하는 것**입니다.
+즉 InnoDI는 네 라이브러리 중 "누가 누구를 만들어 주는가"를 담당합니다.
 
-`InnoDI`의 scope 규칙, declaration order, `concrete: true` 같은 세부 contract는 위에 링크한 [InnoDI 글]({% post_url 2026-02-23-innodi-swift-macro-di %})에서 더 자세히 볼 수 있습니다. 여기서는 그 기능을 어떤 아키텍처 경계에서 써야 하는지에 집중하면 충분합니다.
+## 2. InnoNetwork는 외부 API 실행 정책을 Remote에 가둡니다
 
-## 2. Layers는 InnoDI로 조립하지만 외부에는 얇은 surface만 노출합니다
-
-`LayerContainer`는 `Remote -> Data -> Domain`을 연결하는 composition-only 모듈입니다.
-
-```swift
-public struct LayerContainer {
-    private let remoteContainer: RemoteContainer
-    private let dataContainer: DataContainer
-    private let domainContainer: DomainContainer
-
-    public init(networkTransport: NetworkTransport) {
-        self.remoteContainer = RemoteContainer(networkTransport: networkTransport)
-        self.dataContainer = DataContainer(remoteContainer: remoteContainer)
-        self.domainContainer = DomainContainer(dataContainer: dataContainer)
-    }
-
-    public var featureUseCases: any FeatureUseCaseContaining {
-        domainContainer
-    }
-}
-```
-
-여기서 좋은 점은 외부가 `DomainContainer` 구체 타입을 몰라도 된다는 것입니다. `App`과 `Features`는 `featureUseCases`만 받습니다.
-
-세부 조립은 각 레이어 컨테이너로 더 내려갑니다.
-
-### RemoteContainer
+네트워크 코드는 feature에 직접 들어가면 빠르게 퍼집니다. InnoSample은 `Remote`가 InnoNetwork를 소유하게 합니다.
 
 ```swift
 @DIContainer
 public struct RemoteContainer {
     @Provide(.input)
-    public var networkTransport: NetworkTransport
+    public var baseURL: URL
 
-    @Provide(.shared, factory: { (networkTransport: NetworkTransport) in
-        UserRemoteFactory.make(networkTransport: networkTransport)
+    @Provide(.shared, factory: { (baseURL: URL) in
+        RemoteClientFactory.makeClient(baseURL: baseURL)
+    })
+    var networkClient: any NetworkClient
+
+    @Provide(.shared, factory: { (networkClient: any NetworkClient) in
+        UserRemoteFactory.make(networkClient: networkClient)
     })
     public var userRemoteDataSource: any UserRemoteDataSourceProtocol
 }
 ```
 
-### DataContainer
+`RemoteClientFactory`는 retry, interceptor, timeout 같은 운영 정책을 한곳에서 조립합니다.
 
 ```swift
-@DIContainer
-public struct DataContainer {
-    @Provide(.input)
-    public var remoteContainer: any RemoteDataSourceContaining
-
-    @Provide(.shared, factory: { (remoteContainer: any RemoteDataSourceContaining) in
-        UserRepositoryFactory.make(remoteContainer: remoteContainer)
-    })
-    public var userRepository: any UserRepositoryProtocol
-}
+let configuration = NetworkConfiguration.advanced(
+    baseURL: environment.baseURL,
+    resilience: ResiliencePack(
+        retry: ExponentialBackoffRetryPolicy(maxRetries: 2)
+    ),
+    auth: AuthPack(
+        additionalSigners: [RemoteMetadataInterceptor(environment: environment)],
+        additionalResponseInterceptors: [RemoteStatusInterceptor()]
+    ),
+    transport: TransportPack(timeout: 20.0)
+)
 ```
 
-### DomainContainer
+이렇게 하면 `Feature`는 HTTP를 모릅니다. `Domain`도 `NetworkClient`를 모릅니다. 외부 API 호출 정책은 `Remote` 안에서 끝나고, `Data`는 remote data source contract만 봅니다.
+
+즉 InnoNetwork는 네 라이브러리 중 "외부 세계와 어떻게 통신할 것인가"를 담당합니다.
+
+## 3. Domain과 Data는 앱 언어로 변환합니다
+
+InnoSample에서 `Remote`는 raw API 호출을 하고, `Data`는 repository 구현과 remote data source contract를 소유합니다. `Domain`은 entity, repository protocol, use case를 제공합니다.
+
+이 계층을 유지해야 InnoNetwork의 장점이 feature까지 새지 않습니다.
+
+- `Remote`: API request, DTO, failure mapping
+- `Data`: repository implementation, DTO -> domain mapping
+- `Domain`: use case, domain model, repository protocol
+- `Feature`: use case 호출
+
+use case는 feature가 호출하기 좋은 action object처럼 둡니다. repository는 layer boundary contract이므로 protocol로 유지합니다.
+
+이 배치 덕분에 feature 입장에서는 API가 아니라 "사람 목록을 불러온다", "게시글 목록을 불러온다", "할 일 목록을 불러온다" 같은 앱 언어만 남습니다.
+
+## 4. InnoFlow는 feature 상태 전이를 통제합니다
+
+InnoSample의 feature `Logic` 타깃은 InnoFlow를 사용합니다. 예를 들어 `PeopleFeatureReducer`는 loading, loaded, failed, selected user, settings 이동 intent를 모두 reducer 안에서 다룹니다.
 
 ```swift
-@DIContainer
-public struct DomainContainer: FeatureUseCaseContaining {
-    @Provide(.input)
-    public var dataContainer: any RepositoryContaining
-}
-
-extension DomainContainer {
-    public var fetchPeopleUseCase: FetchPeopleUseCase {
-        FetchPeopleUseCase(repository: dataContainer.userRepository)
-    }
-}
-```
-
-이 패턴이 주는 이점은 분명합니다.
-
-- repository는 진짜 레이어 경계 계약이므로 protocol로 유지합니다.
-- use case는 stateless wrapper이므로 computed concrete value로 가볍게 조합합니다.
-- feature는 repository를 모르고 use case만 받습니다.
-- app root는 remote/data/domain 내부 wiring을 몰라도 됩니다.
-
-즉 `InnoDI`는 전체 그래프를 크게 하나로 만드는 게 아니라, **경계마다 작은 container를 두고 surface를 줄이는 방식**으로 쓰는 편이 낫습니다.
-
-이 지점은 모듈 경계를 먼저 세우고 wiring을 뒤에 얹는 방식이라, 기존에 정리한 [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity %})와도 결이 같습니다.
-
-## 3. InnoFlow는 Logic 타깃 안에서만 비즈니스 상태를 바꾸게 둡니다
-
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)에서 [`InnoFlow`](https://github.com/InnoSquadCorp/InnoFlow)는 feature의 `Logic` 타깃에만 들어갑니다. 예를 들어 `PeopleFeatureReducer`는 이렇게 생겼습니다.
-
-```swift
-@InnoFlow
+@InnoFlow(phaseManaged: true)
 struct PeopleFeatureReducer {
     struct Dependencies: Sendable {
         let loadPeople: @Sendable () async throws -> [UserSummary]
     }
 
     struct State: Equatable, Sendable, DefaultInitializable {
-        var isLoading = false
-        var hasLoaded = false
+        enum Phase: Hashable, Sendable {
+            case idle
+            case loading
+            case loaded
+            case failed
+        }
+
+        var phase: Phase = .idle
         var people: [UserSummary] = []
         var errorMessage: String?
-        var selectedUser: UserSummary?
-        var pendingOverviewRequest: PeopleOverviewRequest?
         var pendingSettingsRequest: PeopleSettingsRequest?
     }
-
-    enum Action: Equatable, Sendable {
-        case onAppear
-        case refresh
-        case peopleLoaded([UserSummary])
-        case peopleFailed(String)
-        case select(UserSummary)
-        case showOverview
-        case openSettings(OpenSettingsRequest)
-    }
 }
 ```
 
-이 구조에서 눈여겨볼 점은 `State` 안에 단순 화면 상태만 있는 것이 아니라, **한 번 소비하고 버릴 intent**도 같이 들어 있다는 점입니다.
+중요한 점은 reducer가 `NetworkClient`나 `NavigationStore`를 직접 모른다는 것입니다.
 
-- `selectedUser`
-- `pendingOverviewRequest`
-- `pendingSettingsRequest`
+- network는 use case closure 뒤에 숨습니다.
+- navigation은 pending intent로만 표현됩니다.
+- UI는 state를 표시하고 action을 보냅니다.
 
-이 값들은 `InnoRouter` 명령 자체가 아닙니다. 대신 reducer가 "이런 이동이 필요하다"는 **도메인 친화적인 요청**만 기록합니다.
+즉 InnoFlow는 네 라이브러리 중 "feature가 어떤 상태로 변하는가"를 담당합니다.
 
-실제 비동기 side effect도 reducer 내부에서 의존성을 통해 실행합니다.
+## 5. InnoRouter는 화면 이동을 데이터화합니다
 
-```swift
-private func loadPeople() -> EffectTask<Action> {
-    let loadPeople = dependencies.loadPeople
-
-    return .run { send, _ in
-        do {
-            let people = try await loadPeople()
-            await send(.peopleLoaded(people))
-        } catch {
-            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            await send(.peopleFailed(message))
-        }
-    }
-    .cancellable("people-feature-load", cancelInFlight: true)
-}
-```
-
-이 방식의 장점은 아래와 같습니다.
-
-- reducer는 `SwiftUI`를 모릅니다.
-- reducer는 `InnoRouter`를 모릅니다.
-- reducer는 use case 실행 결과를 action으로 다시 받습니다.
-- 테스트는 navigation side effect가 아니라 state/action 변화를 기준으로 작성할 수 있습니다.
-
-즉 `InnoFlow`는 "화면 제어 프레임워크"가 아니라, **feature 로직을 상태 전이와 effect로 고정하는 도구**로 쓰는 편이 맞습니다.
-
-`Reducer`, `EffectTask`, `Store`, `PhaseMap` 같은 runtime surface 자체는 [InnoFlow 글]({% post_url 2026-02-23-innoflow-unidirectional-architecture %})에서 더 자세히 다뤘고, 여기서는 그 reducer를 왜 `Logic` 타깃 안에 가둬야 하는지가 더 중요합니다.
-
-## 4. Model은 InnoFlow store를 감싸고, Router는 화면 전환만 맡습니다
-
-`PeopleFeatureModel`은 reducer store를 감싸는 얇은 모델입니다.
+InnoSample의 feature `Router` 타깃은 InnoRouter를 사용합니다. leaf feature는 자기 route만 알고, sibling feature 이동은 상위 `EntireTabCoordinator`가 중재합니다.
 
 ```swift
-@MainActor
-@Observable
-public final class PeopleFeatureModel {
-    private let store: Store<PeopleFeatureReducer>
-
-    public init(loadPeople: @escaping @Sendable () async throws -> [UserSummary]) {
-        self.store = Store(
-            reducer: PeopleFeatureReducer(
-                dependencies: .init(loadPeople: loadPeople)
-            )
-        )
-    }
-
-    public func loadIfNeeded() { store.send(.onAppear) }
-    public func select(_ user: UserSummary) { store.send(.select(user)) }
-
-    public func consumeSettingsRequest() -> OpenSettingsRequest? {
-        let request = store.pendingSettingsRequest?.request
-        guard let request else { return nil }
-        store.send(.clearSettingsRequest)
-        return request
-    }
-}
-```
-
-여기서 model은 reducer의 상태를 SwiftUI 친화적인 public surface로 투영하고, one-shot 요청을 `consume...()` 형태로 꺼내 줍니다.
-
-그 다음 `PeopleFeatureCoordinator`가 `InnoRouter` store를 소유합니다.
-
-```swift
-@MainActor
-@Observable
-public final class PeopleFeatureCoordinator {
-    let navigationStore = NavigationStore<PeopleRoute>()
-    let modalStore = ModalStore<PeopleModalRoute>()
-    let model: PeopleFeatureModel
-
-    func syncNavigationFromSelection() {
-        guard let selectedUser = model.consumeSelectedUser() else { return }
-        navigationStore.send(.resetTo([.detail(selectedUser)]))
-    }
-
-    func syncModalPresentation() {
-        guard let users = model.consumeOverviewUsers() else { return }
-        modalStore.send(.present(.overview(users), style: .sheet))
-    }
-}
-```
-
-여기서 중요한 포인트는 reducer가 `navigationStore.send(...)`를 직접 호출하지 않는다는 것입니다.  
-로직은 로직대로 끝내고, coordinator가 그 결과를 읽어서 route command로 번역합니다.
-
-이 분리가 되면 아래 경계가 깨지지 않습니다.
-
-- `Logic`은 상태와 effect를 소유
-- `Model`은 SwiftUI-friendly projection을 소유
-- `Router/Coordinator`는 navigation state를 소유
-
-## 5. InnoRouter는 feature 내부보다 상위 중재에 더 중요합니다
-
-개별 feature route host는 [`InnoRouter`](https://github.com/InnoSquadCorp/InnoRouter)의 `NavigationHost`, `ModalHost`로 화면을 붙입니다.
-
-```swift
-public struct PeopleFeatureRouteHost: View {
-    let coordinator: PeopleFeatureCoordinator
-
-    public var body: some View {
-        ModalHost(store: coordinator.modalStore) { route in
-            switch route {
-            case .overview(let users):
-                PeopleOverviewSheet(users: users) {
-                    coordinator.modalStore.send(.dismiss)
-                }
-            }
-        } content: {
-            NavigationHost(store: coordinator.navigationStore) { route in
-                switch route {
-                case .detail(let user):
-                    PeopleDetailScreen(user: user, onOpenSettings: coordinator.openSettings)
-                }
-            } root: {
-                PeopleScreen(
-                    model: coordinator.model,
-                    onSelect: coordinator.select,
-                    onShowOverview: coordinator.showOverview
-                )
-            }
-        }
-    }
-}
-```
-
-하지만 이 샘플에서 더 중요한 코드는 `EntireTabCoordinator`입니다.
-
-```swift
-@MainActor
-@Observable
 public final class EntireTabCoordinator: TabCoordinator {
     let peopleCoordinator: PeopleFeatureCoordinator
     let postsCoordinator: PostsFeatureCoordinator
@@ -380,206 +250,72 @@ public final class EntireTabCoordinator: TabCoordinator {
         selectedTab = .settings
         settingsCoordinator.showDetail(assigneeID: request.assigneeID)
     }
-
-    func syncCrossFeatureNavigationFromSettings() {
-        guard let request = settingsCoordinator.consumePeopleRequest() else { return }
-        selectedTab = .people
-        peopleCoordinator.showDetail(userID: request.userID)
-    }
 }
 ```
 
-이 구조가 좋은 이유는 `PeopleFeature`가 `SettingsFeature`를 직접 import 하지 않아도 되기 때문입니다.
+이 구조의 시너지는 큽니다.
 
-즉 흐름은 이렇습니다.
+- `PeopleFeature`는 `SettingsFeature`를 직접 import하지 않습니다.
+- 런타임에서는 `People -> Settings` 이동이 가능합니다.
+- 컴파일 의존은 `People -> EntireTab <- Settings`로 유지됩니다.
+- navigation intent는 InnoFlow에서 만들고, InnoRouter가 실행합니다.
 
-1. `PeopleFeatureReducer`가 `pendingSettingsRequest`를 만든다.
-2. `PeopleFeatureCoordinator`가 그 요청을 꺼낸다.
-3. `EntireTabCoordinator`가 탭 전환과 sibling feature 진입을 중재한다.
-4. `SettingsFeatureCoordinator`가 자신의 route stack을 갱신한다.
+즉 InnoRouter는 네 라이브러리 중 "화면 이동을 어떻게 모델링하고 실행할 것인가"를 담당합니다.
 
-이 패턴을 쓰면 얻는 것이 많습니다.
+## 통합했을 때 생기는 시너지
 
-- sibling feature 간 컴파일 의존 순환을 피할 수 있습니다.
-- cross-feature 이동 정책을 상위 shell에 모을 수 있습니다.
-- 딥링크, 인증, 탭 전환 같은 전역 navigation 판단을 한 곳에서 제어할 수 있습니다.
+네 라이브러리를 한 앱에 넣는다고 자동으로 좋은 구조가 되지는 않습니다. 중요한 것은 각자 맡는 경계를 다르게 두는 것입니다.
 
-즉 `InnoRouter`는 "각 화면에서 push 하는 법"보다 **상위 coordinator가 어떤 이동 권한을 가지는지**를 정리할 때 더 빛납니다.
+InnoSample의 조합은 이렇게 읽을 수 있습니다.
 
-`NavigationStore`, `NavigationHost`, `ModalHost`, `NavigationCommand` 자체 설명은 [InnoRouter 글]({% post_url 2026-02-23-innorouter-swiftui-navigation %})을 보면 됩니다. `InnoSample`이 주는 실전 포인트는 그 surface를 leaf feature보다 **상위 중재 계층**에서 더 전략적으로 쓴다는 점입니다.
+| 책임 | 담당 |
+| --- | --- |
+| 생성과 ownership | InnoDI |
+| 외부 API 실행 정책 | InnoNetwork |
+| 앱 데이터 변환과 use case | Data / Domain |
+| feature 상태 전이 | InnoFlow |
+| 화면 이동 실행 | InnoRouter |
+| UI 공용 지원 | Utils |
+| 최상위 조립 | App / Layers / Features |
 
-## 6. InnoNetwork는 앱 전역에서 직접 쓰지 말고 CoreNetwork 뒤로 숨깁니다
+이 조합의 결과는 다음과 같습니다.
 
-[`InnoSample`](https://github.com/InnoSquadCorp/InnoSample)은 [`InnoNetwork`](https://github.com/InnoSquadCorp/InnoNetwork)를 바로 `Feature`나 `Remote`에 퍼뜨리지 않습니다. 대신 `CoreNetwork`라는 boundary를 하나 둡니다.
+- DI graph가 state machine이 되지 않습니다.
+- reducer가 navigation stack을 직접 조작하지 않습니다.
+- network client가 feature로 새지 않습니다.
+- router가 business logic을 소유하지 않습니다.
+- app root가 모든 leaf 구현을 직접 알지 않습니다.
 
-`NetworkFactory`는 앱 공통 transport 정책을 모읍니다.
+각 라이브러리를 따로 잘 쓰는 것보다, **서로 침범하지 않게 배치하는 것**이 더 큰 가치입니다.
 
-```swift
-public enum NetworkFactory {
-    public static func makeTransport(
-        environment: NetworkEnvironment,
-        session: URLSessionProtocol = URLSession.shared
-    ) -> NetworkTransport {
-        let defaults = makeDefaults(environment: environment)
-        return NetworkTransport(
-            client: makeClient(environment: environment, session: session),
-            defaults: defaults
-        )
-    }
+## 실제 앱으로 가져갈 때의 원칙
 
-    static func makeDefaults(environment: NetworkEnvironment) -> APIDefaults {
-        APIDefaults(
-            environment: environment,
-            logger: RequestLogger(),
-            requestInterceptors: [
-                NetworkMetadataInterceptor(environment: environment),
-            ],
-            responseInterceptors: [
-                NetworkStatusInterceptor(),
-            ]
-        )
-    }
-}
-```
+InnoSample 구조를 그대로 복사할 필요는 없습니다. 하지만 아래 원칙은 유지하는 편이 좋습니다.
 
-그리고 바깥으로는 `NetworkTransport`만 노출합니다.
+1. `App`은 root composition만 담당합니다.
+2. `Layers`는 `Remote/Data/Domain`을 조립하고 feature-facing use case surface만 노출합니다.
+3. `Features`는 leaf feature router와 input을 조립합니다.
+4. leaf feature는 `Interface / Logic / UI / Router / Testing`으로 나눕니다.
+5. `Utils`는 feature UI가 공유하는 디자인 지원처럼 상태 없는 공용 요소만 둡니다.
+6. cross-feature navigation은 leaf끼리 직접 연결하지 않고 상위 coordinator에서 중재합니다.
+7. network policy는 `Remote` 안에 가둡니다.
+8. feature reducer는 use case만 호출합니다.
 
-```swift
-public actor NetworkTransport {
-    public func send<Request: RequestDefinition>(_ request: Request) async throws -> Request.ResponseBody {
-        do {
-            return try await client.perform(executable:
-                RequestAdapter(request: request, apiDefaults: defaults)
-            )
-        } catch let error as NetworkError {
-            throw NetworkFailure(networkError: error)
-        } catch {
-            throw NetworkFailure.transport(SendableUnderlyingError(error), request: nil)
-        }
-    }
-}
-```
+이 원칙을 지키면 앱이 커져도 각 파일이 하는 일이 비교적 선명하게 남습니다.
 
-이 패턴의 핵심은 `InnoNetwork`의 low-level surface를 앱 전체에 공개하지 않는 것입니다.
+## 결론
 
-- retry policy
-- interceptor
-- logger
-- environment
-- request/response adaptation
+InnoSample은 네 라이브러리의 showcase가 아니라, 네 라이브러리를 **서로 다른 아키텍처 경계에 배치하는 예제**입니다.
 
-이런 transport 정책은 `CoreNetwork`가 소유하고, `Remote`는 그냥 요청 정의와 실행만 맡습니다.
+- InnoDI는 생성 경계를 고정합니다.
+- InnoNetwork는 외부 API 실행 정책을 격리합니다.
+- InnoFlow는 feature state transition을 통제합니다.
+- InnoRouter는 navigation을 typed route와 coordinator로 실행합니다.
 
-예를 들어 사용자 조회는 아래처럼 흘러갑니다.
+이 조합의 매력은 "기능이 많다"가 아닙니다. 실무 앱에서 계속 문제가 되는 생성, 상태, 이동, 네트워크 책임을 서로 다른 레이어에 고정한다는 점입니다.
 
-### RequestDefinition
+그래서 InnoSample을 볼 때 가장 중요한 질문은 "이 라이브러리 API를 어떻게 호출하지?"가 아닙니다. 더 좋은 질문은 이것입니다.
 
-```swift
-struct FetchUsersRequest: RequestDefinition {
-    typealias ResponseBody = [UserRemoteModel]
+**내 앱에서도 이 책임 경계를 같은 방식으로 나눌 수 있을까?**
 
-    let featureName = "People"
-    var path: String { "/users" }
-    var headerPolicy: HeaderPolicy { .external }
-}
-```
-
-### RemoteDataSource
-
-```swift
-public actor JSONPlaceholderUserRemoteDataSource: UserRemoteDataSourceProtocol {
-    private let transport: NetworkTransport
-
-    public func fetchUsers() async throws -> [UserRemoteModel] {
-        try await transport.send(FetchUsersRequest())
-    }
-}
-```
-
-### Repository
-
-```swift
-public struct DefaultUserRepository: UserRepositoryProtocol, Sendable {
-    public func fetchUsers() async throws -> [UserSummary] {
-        let users = try await remoteDataSource.fetchUsers()
-        guard !users.isEmpty else {
-            throw DomainError.emptyResponse("사용자")
-        }
-        return users.map(\.domainModel)
-    }
-}
-```
-
-### UseCase
-
-```swift
-public struct FetchPeopleUseCase: Sendable {
-    public func callAsFunction() async throws -> [UserSummary] {
-        try await repository.fetchUsers()
-    }
-}
-```
-
-이 흐름을 보면 `Feature`는 `InnoNetwork`를 모르고, `Domain`도 모릅니다.  
-오직 `CoreNetwork`와 `Remote`만 transport 세부사항을 알고 있습니다.
-
-이게 실제 서비스에서 중요합니다. 네트워크 라이브러리를 바꾸거나 interceptor 정책을 바꾸더라도, 수정 범위를 `CoreNetwork` 쪽으로 최대한 몰 수 있기 때문입니다.
-
-`NetworkConfiguration`, `RetryPolicy`, `InnoNetworkDownload`, `InnoNetworkWebSocket` 같은 제품군 설명은 [InnoNetwork 글]({% post_url 2026-02-23-innonetwork-type-safe-networking %})을 참고하면 됩니다. 이 글에서는 그중 어떤 surface를 앱 아키텍처 어디에 두는지가 핵심입니다.
-
-## 7. 결국 네 라이브러리는 이렇게 나눠 쓰는 편이 좋습니다
-
-`InnoSample` 기준으로 각 라이브러리의 ownership을 한 줄씩 정리하면 이렇습니다.
-
-| 라이브러리 | 소유해야 하는 것 | 소유하면 안 되는 것 |
-| --- | --- | --- |
-| `InnoDI` | container 선언, composition root, layer wiring | 화면 로직, 비즈니스 상태, 전역 service locator 사용 |
-| `InnoFlow` | feature 상태, action, effect, one-shot intent | route stack 직접 제어, SwiftUI view 조립 |
-| `InnoRouter` | stack/modal state, coordinator, cross-feature mediation | 비즈니스 상태 머신, repository 호출 |
-| `InnoNetwork` | request execution, retry, interceptor, logger, transport policy | domain 모델, feature 로직, app-shell wiring |
-
-이 표가 중요한 이유는 "라이브러리를 많이 쓴다"가 좋은 구조를 의미하지 않기 때문입니다.  
-오히려 각 라이브러리를 **자기 경계 바깥으로 넘기지 않는 것**이 더 중요합니다.
-
-## 8. 새 앱에서 그대로 가져가면 좋은 규칙
-
-`InnoSample`을 실제 앱의 출발점으로 쓴다면, 저는 아래 규칙부터 고정하는 편을 권합니다.
-
-1. `AppContainer` 하나만 최상위 composition root로 둡니다.
-2. `CoreNetwork`를 따로 두고 `InnoNetwork` 세부 surface를 감춥니다.
-3. `Layers`는 composition-only 모듈로 유지합니다.
-4. feature는 `Interface / Logic / UI / Router / Testing / Tests`처럼 물리적으로 나눕니다.
-5. `Logic` 타깃에서는 `SwiftUI`, `InnoRouter` import를 금지합니다.
-6. feature 간 직접 이동은 금지하고, 상위 coordinator가 중재하게 합니다.
-7. repository는 protocol, use case는 stateless concrete value를 기본값으로 둡니다.
-
-이 정도만 지켜도, Inno 계열 라이브러리를 "도입한 것"이 아니라 **아키텍처 경계 안에 제대로 배치한 것**에 가까워집니다.
-
-## 마무리
-
-`InnoSample`이 보여주는 가장 중요한 메시지는 이것입니다.
-
-> Inno 라이브러리는 각각 잘 쓰는 것보다, 서로의 책임이 섞이지 않게 쓰는 것이 더 중요합니다.
-
-정리하면:
-
-- `InnoDI`는 조립을 선언합니다.
-- `InnoFlow`는 상태 전이를 관리합니다.
-- `InnoRouter`는 화면 흐름과 feature 간 이동을 중재합니다.
-- `InnoNetwork`는 transport policy를 캡슐화합니다.
-
-이 네 개가 한 파일 안에서 다 보이면 구조가 잘못됐을 가능성이 높습니다.  
-반대로 `InnoSample`처럼 `App -> Layers -> Features` 경계 안에서 각각 등장 위치가 분리되어 있으면, 그때부터는 새 기능이 들어와도 구조가 쉽게 무너지지 않습니다.
-
-관련 글도 같이 보면 흐름이 더 자연스럽습니다.
-
-- 아키텍처 배경: [Understanding Modularity]({% post_url 2024-04-27-understanding-modularity %}), [Clean Architecture]({% post_url 2024-05-13-clean-architecture %})
-- 라이브러리 상세: [InnoDI]({% post_url 2026-02-23-innodi-swift-macro-di %}), [InnoFlow]({% post_url 2026-02-23-innoflow-unidirectional-architecture %}), [InnoRouter]({% post_url 2026-02-23-innorouter-swiftui-navigation %}), [InnoNetwork]({% post_url 2026-02-23-innonetwork-type-safe-networking %})
-
-## 레포 링크
-
-- [InnoSample GitHub 저장소](https://github.com/InnoSquadCorp/InnoSample)
-- [InnoDI GitHub 저장소](https://github.com/InnoSquadCorp/InnoDI)
-- [InnoFlow GitHub 저장소](https://github.com/InnoSquadCorp/InnoFlow)
-- [InnoRouter GitHub 저장소](https://github.com/InnoSquadCorp/InnoRouter)
-- [InnoNetwork GitHub 저장소](https://github.com/InnoSquadCorp/InnoNetwork)
+그 답이 yes라면, Inno 계열 라이브러리는 단순 도구 모음이 아니라 앱 구조를 오래 유지하기 위한 좋은 출발점이 됩니다.


### PR DESCRIPTION
## Summary
- Refresh 10 Korean/English Inno blog posts around practical best practices and adoption appeal.
- Reframe individual library posts around why to use each library, where it should live, and what benefits it gives in real apps.
- Rework the InnoSample posts as the hub for how InnoDI, InnoFlow, InnoRouter, and InnoNetwork create synergy when placed at separate architecture boundaries.

## Notes
- Keeps existing slugs and translation keys.
- Updates content around current InnoSample package versions: InnoDI 4.3.0, InnoFlow 4.0.0, InnoNetwork 4.0.0, InnoRouter 4.2.1.
- Changes blog content only; no Inno library or InnoSample source changes.

## Validation
- bundle exec jekyll build --quiet
- git diff --check
- Searched target posts for stale 2.x/3.x version references.